### PR TITLE
update grafana and prometheus images 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM prom/prometheus:v2.45.0 as prometheus
+FROM prom/prometheus:v2.50.1 as prometheus
 
-FROM grafana/grafana:9.5.6-ubuntu as grafana
+FROM grafana/grafana:10.2.4-ubuntu as grafana
 
 USER root
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,12 @@ Create an `.env` file:
 cp .env.example .env
 ```
 
-Fill it out with your project details. You'll need your project ref and service role key, which you can find [here](https://app.supabase.com/project/_/settings/api).
-Alternatively, to monitor multiple projects you'll need to create an access token [here](https://supabase.com/dashboard/account/tokens).
+
+Fill it out with your project details.
+
+1. To monitor a single project, fill out your `project ref` and `service role key`,  which you can find [here](https://app.supabase.com/project/_/settings/api).
+
+2. Alternatively, to monitor multiple projects you'll need to create an access token [here](https://supabase.com/dashboard/account/tokens).
 
 ### Run with Docker
 


### PR DESCRIPTION

## What kind of change does this PR introduce?

- Update Grafana to 10.2.4
- Update Prometheus to 2.50.1
- Modify README to clarify single vs multiple project monitoring (Closes #13 )

## What is the current behavior?

Current Grafana is on v9 and Prometheus is on 2.45.0

## What is the new behavior?

Grafana is on v10 and Prometheus is 2.50.1.

Readme is hopefully clearer in explaining how to configure single project vs multi project monitoring.

## Additional context

Add any other context or screenshots.
