### PR TITLE
Add instructions for self-hosting using Caprover

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,17 @@ Follow these steps:
 2. Run `fly launch` to deploy the app to Fly.
 3. Copy your `.env` file to your Fly project: `fly secrets import < .env`
 4. After a successful deployment, your app will be available at `https://<your-app-name>.fly.dev`
+
+### Using Caprover for self-hosting
+
+You can also run the collector on your own server using [Caprover](https://caprover.com/).
+
+Follow these steps:
+
+1. Create a new app on Caprover with persistent data. <br>
+   Optional:
+   - Set container http port to 8080.
+   - Enable HTTPS and force redirect.
+2. Copy your `.env` file to your Caprover app configuration.
+3. Add persistent storage for the `/data` directory.
+4. Deploy the app.

--- a/captain-definition
+++ b/captain-definition
@@ -1,0 +1,4 @@
+{
+  "schemaVersion": 2,
+  "dockerfilePath": "./Dockerfile"
+ }


### PR DESCRIPTION
## Description

This pull request updates the documentation for deploying to Caprover for self-hosting. It includes a captain-definition file that can be used for deploying to Caprover.

## Current Behavior

Currently, Caprover works but there are no documentation for it. This pull request aims to address this issue by providing the necessary instructions and files.

## New Behavior

With this update, users will have clear instructions and a captain-definition file to deploy their application to Caprover.
