### PR TITLE
fix: add a base fly app configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ You can run the collector on a free instance of [Fly.io](https://fly.io/)
 Follow these steps:
 
 1. Make sure you have the [Fly CLI](https://fly.io/docs/getting-started/installing-flyctl/) installed, and you are logged in.
+2. Run `fly volume create supabase_metrics_data`. Please note that you must create the volume in the same region as you will launch your app.
+   Failing to do so will result in data loss upon app restarts.
 2. Run `fly launch` to deploy the app to Fly.
 3. Copy your `.env` file to your Fly project: `fly secrets import < .env`
 4. After a successful deployment, your app will be available at `https://<your-app-name>.fly.dev`

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,13 @@
+app = "supabase-grafana-metrics"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = false
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ["app"]
+
+[mounts]
+  source="supabase_metrics_data"
+  destination="/data"


### PR DESCRIPTION
`fly launch` defaults to apps stopping after a period of
inactivity. Since a persistent volume is also not configured, this
would result in historical data being lost on every pause.

This change adds a fly.toml that disables auto-stop for the app that
will be launched.

Additionally, a persistent volume is also defined, and the readme is
updated to indicate that it needs to be explicitly created.

In theory the `fly launch` command should pick up the config from the
fly.toml file. In practice this doesn't seem to happen.

The bug removing the Fly app config was introduced in an earlier
change 35503f5aaa916ab31f82cb37e1133df2cb82b101