### PR TITLE
Enforce LF line endings for .sh files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
This PR updates the `.gitattributes` file to enforce LF line endings for all `.sh` files.

Regardless of the operating system, it should now fix:
- https://github.com/supabase/supabase-grafana/issues/10