### PR TITLE
chore: increase scrape interval to 60s

### DIFF
--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,4 +1,4 @@
 global:
-  scrape_interval: 5s
+  scrape_interval: 60s
 
 scrape_configs:


### PR DESCRIPTION
Most of our metrics currently cache for 60s; there's no point in
scraping more frequently than that.