### PR TITLE
Upgrade prometheus to 2.53.4 and grafana to 11.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM prom/prometheus:v2.50.1 as prometheus
+FROM prom/prometheus:v2.53.4 AS prometheus
 
-FROM grafana/grafana:10.2.4-ubuntu as grafana
+FROM grafana/grafana:11.6.0-ubuntu AS grafana
 
 USER root
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,5 +10,6 @@ services:
       SUPABASE_SERVICE_ROLE_KEY: ${SUPABASE_SERVICE_ROLE_KEY}
       PASSWORD_PROTECTED: ${PASSWORD_PROTECTED}
       GRAFANA_PASSWORD: ${GRAFANA_PASSWORD}
+    platform: linux/amd64
     volumes:
       - ./data:/data

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -67,7 +67,7 @@ if [ "$PASSWORD_PROTECTED" = "true" ]; then
 
   export GF_SECURITY_ADMIN_PASSWORD="$GRAFANA_PASSWORD"
 
-  cd /usr/share/grafana && grafana-cli admin reset-admin-password "$GRAFANA_PASSWORD"
+  cd /usr/share/grafana && grafana cli admin reset-admin-password "$GRAFANA_PASSWORD"
 fi
 
 /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update

## What is the current behavior?

Current Prometheus version is 2.50.1 and Grafana is 10.2.4

## What is the new behavior?

Upgrade to 2.53.4 and Grafana to 11.6. `grafana-cli` is being deprecated so modified entrypoint to use `grafana cli`

## Additional context

Closes #32 
