### PR TITLE
Add support for `supabase_identifier`

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ A managed Prometheus instance can be deployed on [Grafana Cloud](https://grafana
 ### Prometheus - Adding your Scrape Job
 
 Configure your Prometheus instance with a scrape job that looks like this:
-```
+
+```yaml
 scrape_configs:
   - job_name: "<YOUR JOB NAME>"
     metrics_path: "/customer/v1/privileged/metrics"
@@ -97,7 +98,7 @@ As an example, if the identifier for your read replica is `foobarbaz-us-east-1-a
     static_configs:
       - targets: ["foobarbaz-us-east-1-abcdef.supabase.co"]
         labels:
-          supabase_project_ref: "foobarbaz-us-east-1-abcdef"
+          group: "<YOUR LABEL CHOICE>"
 ```
 ### Deploy Grafana
 

--- a/dashboard.json
+++ b/dashboard.json
@@ -1,9874 +1,9890 @@
 {
-    "__inputs": [
-      {
-        "name": "DS_PROMETHEUS",
-        "label": "prometheus",
-        "description": "",
-        "type": "datasource",
-        "pluginId": "prometheus",
-        "pluginName": "Prometheus"
-      }
-    ],
-    "__elements": {},
-    "__requires": [
-      {
-        "type": "panel",
-        "id": "gauge",
-        "name": "Gauge",
-        "version": ""
-      },
-      {
-        "type": "grafana",
-        "id": "grafana",
-        "name": "Grafana",
-        "version": "11.5.1"
-      },
-      {
-        "type": "datasource",
-        "id": "prometheus",
-        "name": "Prometheus",
-        "version": "1.0.0"
-      },
-      {
-        "type": "panel",
-        "id": "stat",
-        "name": "Stat",
-        "version": ""
-      },
-      {
-        "type": "panel",
-        "id": "timeseries",
-        "name": "Time series",
-        "version": ""
-      }
-    ],
-    "annotations": {
-      "list": [
-        {
-          "builtIn": 1,
-          "datasource": {
-            "type": "grafana",
-            "uid": "-- Grafana --"
-          },
-          "enable": true,
-          "hide": true,
-          "iconColor": "rgba(0, 211, 255, 1)",
-          "name": "Annotations & Alerts",
-          "type": "dashboard"
-        }
-      ]
+  "__inputs": [
+    {
+      "name": "DS_GRAFANACLOUD-ENCIMA-PROM",
+      "label": "grafanacloud-encima-prom",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
     },
-    "editable": true,
-    "fiscalYearStartMonth": 0,
-    "graphTooltip": 0,
-    "id": null,
-    "links": [],
-    "panels": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "12.1.0-88993"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
       {
-        "collapsed": false,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 0
-        },
-        "id": 261,
-        "panels": [],
-        "title": "Quick CPU / Mem / Disk",
-        "type": "row"
-      },
-      {
+        "builtIn": 1,
         "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "description": "Busy state of all CPU cores together",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [
-              {
-                "options": {
-                  "match": "null",
-                  "result": {
-                    "text": "N/A"
-                  }
-                },
-                "type": "special"
-              }
-            ],
-            "max": 100,
-            "min": 0,
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "rgba(50, 172, 45, 0.97)",
-                  "value": null
-                },
-                {
-                  "color": "rgba(237, 129, 40, 0.89)",
-                  "value": 85
-                },
-                {
-                  "color": "rgba(245, 54, 54, 0.9)",
-                  "value": 95
-                }
-              ]
-            },
-            "unit": "percent"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 4,
-          "w": 3,
-          "x": 0,
-          "y": 1
-        },
-        "id": 20,
-        "options": {
-          "minVizHeight": 75,
-          "minVizWidth": 75,
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showThresholdLabels": false,
-          "showThresholdMarkers": true,
-          "sizing": "auto"
-        },
-        "pluginVersion": "11.5.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "editorMode": "code",
-            "expr": "clamp_min(100 - (avg(rate(node_cpu_seconds_total{mode=\"idle\", supabase_project_ref=\"$project\"}[$__rate_interval])) by (i) * 100), 0)",
-            "hide": false,
-            "intervalFactor": 1,
-            "legendFormat": "",
-            "range": true,
-            "refId": "A",
-            "step": 240
-          }
-        ],
-        "title": "CPU Busy",
-        "type": "gauge"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "description": "Busy state of all CPU cores together (5 min average)",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [
-              {
-                "options": {
-                  "match": "null",
-                  "result": {
-                    "text": "N/A"
-                  }
-                },
-                "type": "special"
-              }
-            ],
-            "max": 100,
-            "min": 0,
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "rgba(50, 172, 45, 0.97)",
-                  "value": null
-                },
-                {
-                  "color": "rgba(237, 129, 40, 0.89)",
-                  "value": 85
-                },
-                {
-                  "color": "rgba(245, 54, 54, 0.9)",
-                  "value": 95
-                }
-              ]
-            },
-            "unit": "percent"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 4,
-          "w": 3,
-          "x": 3,
-          "y": 1
-        },
-        "id": 155,
-        "options": {
-          "minVizHeight": 75,
-          "minVizWidth": 75,
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showThresholdLabels": false,
-          "showThresholdMarkers": true,
-          "sizing": "auto"
-        },
-        "pluginVersion": "11.5.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "expr": "avg(node_load5{supabase_project_ref=\"$project\"}) /  count(count(node_cpu_seconds_total{supabase_project_ref=\"$project\"}) by (cpu)) * 100",
-            "format": "time_series",
-            "hide": false,
-            "intervalFactor": 1,
-            "refId": "A",
-            "step": 240
-          }
-        ],
-        "title": "Sys Load (5m avg)",
-        "type": "gauge"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "description": "Busy state of all CPU cores together (15 min average)",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [
-              {
-                "options": {
-                  "match": "null",
-                  "result": {
-                    "text": "N/A"
-                  }
-                },
-                "type": "special"
-              }
-            ],
-            "max": 100,
-            "min": 0,
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "rgba(50, 172, 45, 0.97)",
-                  "value": null
-                },
-                {
-                  "color": "rgba(237, 129, 40, 0.89)",
-                  "value": 85
-                },
-                {
-                  "color": "rgba(245, 54, 54, 0.9)",
-                  "value": 95
-                }
-              ]
-            },
-            "unit": "percent"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 4,
-          "w": 3,
-          "x": 6,
-          "y": 1
-        },
-        "id": 19,
-        "options": {
-          "minVizHeight": 75,
-          "minVizWidth": 75,
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showThresholdLabels": false,
-          "showThresholdMarkers": true,
-          "sizing": "auto"
-        },
-        "pluginVersion": "11.5.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "expr": "avg(node_load15{supabase_project_ref=\"$project\"}) /  count(count(node_cpu_seconds_total{supabase_project_ref=\"$project\"}) by (cpu)) * 100",
-            "hide": false,
-            "intervalFactor": 1,
-            "refId": "A",
-            "step": 240
-          }
-        ],
-        "title": "Sys Load (15m avg)",
-        "type": "gauge"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "description": "Non available RAM memory",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "decimals": 0,
-            "mappings": [],
-            "max": 100,
-            "min": 0,
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "rgba(50, 172, 45, 0.97)",
-                  "value": null
-                },
-                {
-                  "color": "rgba(237, 129, 40, 0.89)",
-                  "value": 80
-                },
-                {
-                  "color": "rgba(245, 54, 54, 0.9)",
-                  "value": 90
-                }
-              ]
-            },
-            "unit": "percent"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 4,
-          "w": 3,
-          "x": 9,
-          "y": 1
-        },
-        "id": 16,
-        "options": {
-          "minVizHeight": 75,
-          "minVizWidth": 75,
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showThresholdLabels": false,
-          "showThresholdMarkers": true,
-          "sizing": "auto"
-        },
-        "pluginVersion": "11.5.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "expr": "((node_memory_MemTotal_bytes{supabase_project_ref=\"$project\"} - node_memory_MemFree_bytes{supabase_project_ref=\"$project\"}) / (node_memory_MemTotal_bytes{supabase_project_ref=\"$project\"} )) * 100",
-            "format": "time_series",
-            "hide": true,
-            "intervalFactor": 1,
-            "refId": "A",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "expr": "100 - ((node_memory_MemAvailable_bytes{supabase_project_ref=\"$project\"} * 100) / node_memory_MemTotal_bytes{supabase_project_ref=\"$project\"})",
-            "format": "time_series",
-            "hide": false,
-            "intervalFactor": 1,
-            "refId": "B",
-            "step": 240
-          }
-        ],
-        "title": "RAM Used",
-        "type": "gauge"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "description": "Used Swap",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [
-              {
-                "options": {
-                  "match": "null",
-                  "result": {
-                    "text": "N/A"
-                  }
-                },
-                "type": "special"
-              }
-            ],
-            "max": 100,
-            "min": 0,
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "rgba(50, 172, 45, 0.97)",
-                  "value": null
-                },
-                {
-                  "color": "rgba(237, 129, 40, 0.89)",
-                  "value": 10
-                },
-                {
-                  "color": "rgba(245, 54, 54, 0.9)",
-                  "value": 25
-                }
-              ]
-            },
-            "unit": "percent"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 4,
-          "w": 3,
-          "x": 12,
-          "y": 1
-        },
-        "id": 21,
-        "options": {
-          "minVizHeight": 75,
-          "minVizWidth": 75,
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showThresholdLabels": false,
-          "showThresholdMarkers": true,
-          "sizing": "auto"
-        },
-        "pluginVersion": "11.5.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "expr": "((node_memory_SwapTotal_bytes{supabase_project_ref=\"$project\"} - node_memory_SwapFree_bytes{supabase_project_ref=\"$project\"}) / (node_memory_SwapTotal_bytes{supabase_project_ref=\"$project\"} )) * 100",
-            "intervalFactor": 1,
-            "refId": "A",
-            "step": 240
-          }
-        ],
-        "title": "SWAP Used",
-        "type": "gauge"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "description": "Used Root FS",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [
-              {
-                "options": {
-                  "match": "null",
-                  "result": {
-                    "text": "N/A"
-                  }
-                },
-                "type": "special"
-              }
-            ],
-            "max": 100,
-            "min": 0,
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "rgba(50, 172, 45, 0.97)",
-                  "value": null
-                },
-                {
-                  "color": "rgba(237, 129, 40, 0.89)",
-                  "value": 80
-                },
-                {
-                  "color": "rgba(245, 54, 54, 0.9)",
-                  "value": 90
-                }
-              ]
-            },
-            "unit": "percent"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 4,
-          "w": 3,
-          "x": 15,
-          "y": 1
-        },
-        "id": 154,
-        "options": {
-          "minVizHeight": 75,
-          "minVizWidth": 75,
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showThresholdLabels": false,
-          "showThresholdMarkers": true,
-          "sizing": "auto"
-        },
-        "pluginVersion": "11.5.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "expr": "100 - ((node_filesystem_avail_bytes{supabase_project_ref=\"$project\",mountpoint=\"/\",fstype!=\"rootfs\"} * 100) / node_filesystem_size_bytes{supabase_project_ref=\"$project\",mountpoint=\"/\",fstype!=\"rootfs\"})",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "refId": "A",
-            "step": 240
-          }
-        ],
-        "title": "Root FS Used",
-        "type": "gauge"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "description": "Total number of CPU cores",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [
-              {
-                "options": {
-                  "match": "null",
-                  "result": {
-                    "text": "N/A"
-                  }
-                },
-                "type": "special"
-              }
-            ],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "short"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 2,
-          "w": 2,
-          "x": 18,
-          "y": 1
-        },
-        "id": 14,
-        "maxDataPoints": 100,
-        "options": {
-          "colorMode": "none",
-          "graphMode": "none",
-          "justifyMode": "auto",
-          "orientation": "horizontal",
-          "percentChangeColorMode": "standard",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showPercentChange": false,
-          "textMode": "auto",
-          "wideLayout": true
-        },
-        "pluginVersion": "11.5.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "expr": "count(count(node_cpu_seconds_total{supabase_project_ref=\"$project\"}) by (cpu))",
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "",
-            "refId": "A",
-            "step": 240
-          }
-        ],
-        "title": "CPU Cores",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "description": "System uptime",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "decimals": 1,
-            "mappings": [
-              {
-                "options": {
-                  "match": "null",
-                  "result": {
-                    "text": "N/A"
-                  }
-                },
-                "type": "special"
-              }
-            ],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "s"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 2,
-          "w": 2,
-          "x": 20,
-          "y": 1
-        },
-        "id": 15,
-        "maxDataPoints": 100,
-        "options": {
-          "colorMode": "none",
-          "graphMode": "none",
-          "justifyMode": "auto",
-          "orientation": "horizontal",
-          "percentChangeColorMode": "standard",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showPercentChange": false,
-          "textMode": "auto",
-          "wideLayout": true
-        },
-        "pluginVersion": "11.5.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "node_time_seconds{supabase_project_ref=\"$project\"} - node_boot_time_seconds{supabase_project_ref=\"$project\"}",
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "",
-            "refId": "A",
-            "step": 240
-          }
-        ],
-        "title": "Uptime",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "description": "Total SWAP",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "decimals": 0,
-            "mappings": [
-              {
-                "options": {
-                  "match": "null",
-                  "result": {
-                    "text": "N/A"
-                  }
-                },
-                "type": "special"
-              }
-            ],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "bytes"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 2,
-          "w": 2,
-          "x": 22,
-          "y": 1
-        },
-        "id": 18,
-        "maxDataPoints": 100,
-        "options": {
-          "colorMode": "none",
-          "graphMode": "none",
-          "justifyMode": "auto",
-          "orientation": "horizontal",
-          "percentChangeColorMode": "standard",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showPercentChange": false,
-          "textMode": "auto",
-          "wideLayout": true
-        },
-        "pluginVersion": "11.5.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "expr": "node_memory_SwapTotal_bytes{supabase_project_ref=\"$project\"}",
-            "intervalFactor": 1,
-            "refId": "A",
-            "step": 240
-          }
-        ],
-        "title": "SWAP Total",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "description": "Total RootFS",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "decimals": 0,
-            "mappings": [
-              {
-                "options": {
-                  "match": "null",
-                  "result": {
-                    "text": "N/A"
-                  }
-                },
-                "type": "special"
-              }
-            ],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "rgba(50, 172, 45, 0.97)",
-                  "value": null
-                },
-                {
-                  "color": "rgba(237, 129, 40, 0.89)",
-                  "value": 70
-                },
-                {
-                  "color": "rgba(245, 54, 54, 0.9)",
-                  "value": 90
-                }
-              ]
-            },
-            "unit": "bytes"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 2,
-          "w": 2,
-          "x": 18,
-          "y": 3
-        },
-        "id": 23,
-        "maxDataPoints": 100,
-        "options": {
-          "colorMode": "none",
-          "graphMode": "none",
-          "justifyMode": "auto",
-          "orientation": "horizontal",
-          "percentChangeColorMode": "standard",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showPercentChange": false,
-          "textMode": "auto",
-          "wideLayout": true
-        },
-        "pluginVersion": "11.5.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "node_filesystem_size_bytes{supabase_project_ref=\"$project\",mountpoint=\"/\",fstype!=\"rootfs\"}",
-            "format": "time_series",
-            "hide": false,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "",
-            "refId": "A",
-            "step": 240
-          }
-        ],
-        "title": "RootFS Total",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "description": "Total data disk capacity",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "decimals": 0,
-            "mappings": [
-              {
-                "options": {
-                  "match": "null",
-                  "result": {
-                    "text": "N/A"
-                  }
-                },
-                "type": "special"
-              }
-            ],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "rgba(50, 172, 45, 0.97)",
-                  "value": null
-                },
-                {
-                  "color": "rgba(237, 129, 40, 0.89)",
-                  "value": 70
-                },
-                {
-                  "color": "rgba(245, 54, 54, 0.9)",
-                  "value": 90
-                }
-              ]
-            },
-            "unit": "bytes"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 2,
-          "w": 2,
-          "x": 20,
-          "y": 3
-        },
-        "id": 322,
-        "maxDataPoints": 100,
-        "options": {
-          "colorMode": "none",
-          "graphMode": "none",
-          "justifyMode": "auto",
-          "orientation": "horizontal",
-          "percentChangeColorMode": "standard",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showPercentChange": false,
-          "textMode": "auto",
-          "wideLayout": true
-        },
-        "pluginVersion": "11.5.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "node_filesystem_size_bytes{supabase_project_ref=\"$project\",mountpoint=\"/data\",fstype!=\"rootfs\"}",
-            "format": "time_series",
-            "hide": false,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "",
-            "queryType": "measurements",
-            "refId": "A",
-            "step": 240
-          }
-        ],
-        "title": "Data Disk Total",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "description": "Total RAM",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "decimals": 0,
-            "mappings": [
-              {
-                "options": {
-                  "match": "null",
-                  "result": {
-                    "text": "N/A"
-                  }
-                },
-                "type": "special"
-              }
-            ],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "bytes"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 2,
-          "w": 2,
-          "x": 22,
-          "y": 3
-        },
-        "id": 75,
-        "maxDataPoints": 100,
-        "options": {
-          "colorMode": "none",
-          "graphMode": "none",
-          "justifyMode": "auto",
-          "orientation": "horizontal",
-          "percentChangeColorMode": "standard",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showPercentChange": false,
-          "textMode": "auto",
-          "wideLayout": true
-        },
-        "pluginVersion": "11.5.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "expr": "node_memory_MemTotal_bytes{supabase_project_ref=\"$project\"}",
-            "intervalFactor": 1,
-            "refId": "A",
-            "step": 240
-          }
-        ],
-        "title": "RAM Total",
-        "type": "stat"
-      },
-      {
-        "collapsed": false,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 5
-        },
-        "id": 263,
-        "panels": [],
-        "title": "Basic CPU / Mem / Net / Disk",
-        "type": "row"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "description": "Basic CPU info",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisBorderShow": false,
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "barWidthFactor": 0.6,
-              "drawStyle": "line",
-              "fillOpacity": 40,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "insertNulls": false,
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "never",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "percent"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "links": [],
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "short"
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Busy"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#EAB839",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Busy Iowait"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#890F02",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Busy other"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#1F78C1",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Idle"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#052B51",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Idle - Waiting for something to happen"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#052B51",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "guest"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#9AC48A",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "idle"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#052B51",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "iowait"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#EAB839",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "irq"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#BF1B00",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "nice"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#C15C17",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "softirq"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#E24D42",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "steal"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#FCE2DE",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "system"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#508642",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "user"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#5195CE",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Busy Iowait"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#890F02",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Idle"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#7EB26D",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Busy System"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#EAB839",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Busy User"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#0A437C",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Busy Other"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#6D1F62",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "gridPos": {
-          "h": 7,
-          "w": 12,
-          "x": 0,
-          "y": 6
-        },
-        "id": 77,
-        "maxPerRow": 6,
-        "options": {
-          "alertThreshold": true,
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": true,
-            "width": 250
-          },
-          "tooltip": {
-            "hideZeros": false,
-            "mode": "multi",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "11.5.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode=\"system\",supabase_project_ref=\"$project\"}[$__rate_interval])) * 100",
-            "format": "time_series",
-            "hide": false,
-            "intervalFactor": 1,
-            "legendFormat": "Busy System",
-            "refId": "A",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode='user',supabase_project_ref=\"$project\"}[$__rate_interval])) * 100",
-            "format": "time_series",
-            "hide": false,
-            "intervalFactor": 1,
-            "legendFormat": "Busy User",
-            "refId": "B",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode='iowait',supabase_project_ref=\"$project\"}[$__rate_interval])) * 100",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "Busy Iowait",
-            "refId": "C",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode=~\".*irq\",supabase_project_ref=\"$project\"}[$__rate_interval])) * 100",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "Busy IRQs",
-            "refId": "D",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "expr": "sum (rate(node_cpu_seconds_total{mode!='idle',mode!='user',mode!='system',mode!='iowait',mode!='irq',mode!='softirq',supabase_project_ref=\"$project\"}[$__rate_interval])) * 100",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "Busy Other",
-            "refId": "E",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='idle',supabase_project_ref=\"$project\"}[$__rate_interval])) * 100",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "Idle",
-            "refId": "F",
-            "step": 240
-          }
-        ],
-        "title": "CPU Basic",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "description": "Basic memory usage",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisBorderShow": false,
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "barWidthFactor": 0.6,
-              "drawStyle": "line",
-              "fillOpacity": 40,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "insertNulls": false,
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "never",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "normal"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "links": [],
-            "mappings": [],
-            "min": 0,
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "bytes"
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Apps"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#629E51",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Buffers"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#614D93",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Cache"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#6D1F62",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Cached"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#511749",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Committed"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#508642",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Free"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#0A437C",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Hardware Corrupted - Amount of RAM that the kernel identified as corrupted / not working"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#CFFAFF",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Inactive"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#584477",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "PageTables"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#0A50A1",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Page_Tables"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#0A50A1",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "RAM_Free"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#E0F9D7",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "SWAP Used"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#BF1B00",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Slab"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#806EB7",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Slab_Cache"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#E0752D",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Swap"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#BF1B00",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Swap Used"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#BF1B00",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Swap_Cache"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#C15C17",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Swap_Free"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#2F575E",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Unused"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#EAB839",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "RAM Total"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#E0F9D7",
-                    "mode": "fixed"
-                  }
-                },
-                {
-                  "id": "custom.fillOpacity",
-                  "value": 0
-                },
-                {
-                  "id": "custom.stacking",
-                  "value": {
-                    "group": "A",
-                    "mode": "none"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "RAM Cache + Buffer"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#052B51",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "RAM Free"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#7EB26D",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Avaliable"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#DEDAF7",
-                    "mode": "fixed"
-                  }
-                },
-                {
-                  "id": "custom.fillOpacity",
-                  "value": 0
-                },
-                {
-                  "id": "custom.stacking",
-                  "value": {
-                    "group": "A",
-                    "mode": "none"
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "gridPos": {
-          "h": 7,
-          "w": 12,
-          "x": 12,
-          "y": 6
-        },
-        "id": 78,
-        "maxPerRow": 6,
-        "options": {
-          "alertThreshold": true,
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": true,
-            "width": 350
-          },
-          "tooltip": {
-            "hideZeros": false,
-            "mode": "multi",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "11.5.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "expr": "node_memory_MemTotal_bytes{supabase_project_ref=\"$project\"}",
-            "format": "time_series",
-            "hide": false,
-            "intervalFactor": 1,
-            "legendFormat": "RAM Total",
-            "refId": "A",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "expr": "node_memory_MemTotal_bytes{supabase_project_ref=\"$project\"} - node_memory_MemFree_bytes{supabase_project_ref=\"$project\"} - (node_memory_Cached_bytes{supabase_project_ref=\"$project\"} + node_memory_Buffers_bytes{supabase_project_ref=\"$project\"})",
-            "format": "time_series",
-            "hide": false,
-            "intervalFactor": 1,
-            "legendFormat": "RAM Used",
-            "refId": "B",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "expr": "node_memory_Cached_bytes{supabase_project_ref=\"$project\"} + node_memory_Buffers_bytes{supabase_project_ref=\"$project\"}",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "RAM Cache + Buffer",
-            "refId": "C",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "expr": "node_memory_MemFree_bytes{supabase_project_ref=\"$project\"}",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "RAM Free",
-            "refId": "D",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "expr": "(node_memory_SwapTotal_bytes{supabase_project_ref=\"$project\"} - node_memory_SwapFree_bytes{supabase_project_ref=\"$project\"})",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "SWAP Used",
-            "refId": "E",
-            "step": 240
-          }
-        ],
-        "title": "Memory Basic",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "description": "Basic network info per interface",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisBorderShow": false,
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "barWidthFactor": 0.6,
-              "drawStyle": "line",
-              "fillOpacity": 40,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "insertNulls": false,
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "never",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "links": [],
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "bps"
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Recv_bytes_eth2"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#7EB26D",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Recv_bytes_lo"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#0A50A1",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Recv_drop_eth2"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#6ED0E0",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Recv_drop_lo"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#E0F9D7",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Recv_errs_eth2"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#BF1B00",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Recv_errs_lo"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#CCA300",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Trans_bytes_eth2"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#7EB26D",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Trans_bytes_lo"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#0A50A1",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Trans_drop_eth2"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#6ED0E0",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Trans_drop_lo"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#E0F9D7",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Trans_errs_eth2"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#BF1B00",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Trans_errs_lo"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#CCA300",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "recv_bytes_lo"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#0A50A1",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "recv_drop_eth0"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#99440A",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "recv_drop_lo"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#967302",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "recv_errs_eth0"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#BF1B00",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "recv_errs_lo"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#890F02",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "trans_bytes_eth0"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#7EB26D",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "trans_bytes_lo"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#0A50A1",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "trans_drop_eth0"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#99440A",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "trans_drop_lo"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#967302",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "trans_errs_eth0"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#BF1B00",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "trans_errs_lo"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#890F02",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byRegexp",
-                "options": "/.*trans.*/"
-              },
-              "properties": [
-                {
-                  "id": "custom.transform",
-                  "value": "negative-Y"
-                }
-              ]
-            }
-          ]
-        },
-        "gridPos": {
-          "h": 7,
-          "w": 12,
-          "x": 0,
-          "y": 13
-        },
-        "id": 74,
-        "options": {
-          "alertThreshold": true,
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": true
-          },
-          "tooltip": {
-            "hideZeros": false,
-            "mode": "multi",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "11.5.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "expr": "rate(node_network_receive_bytes_total{supabase_project_ref=\"$project\"}[$__rate_interval])*8",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "recv {{device}}",
-            "refId": "A",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "expr": "rate(node_network_transmit_bytes_total{supabase_project_ref=\"$project\"}[$__rate_interval])*8",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "trans {{device}} ",
-            "refId": "B",
-            "step": 240
-          }
-        ],
-        "title": "Network Traffic Basic",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "description": "Disk space used of all filesystems mounted",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisBorderShow": false,
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "barWidthFactor": 0.6,
-              "drawStyle": "line",
-              "fillOpacity": 40,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "insertNulls": false,
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "never",
-              "spanNulls": true,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "links": [],
-            "mappings": [],
-            "max": 100,
-            "min": 0,
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "percent"
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "EBS Balance"
-              },
-              "properties": [
-                {
-                  "id": "custom.fillOpacity",
-                  "value": 0
-                }
-              ]
-            }
-          ]
-        },
-        "gridPos": {
-          "h": 7,
-          "w": 12,
-          "x": 12,
-          "y": 13
-        },
-        "id": 152,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": true
-          },
-          "tooltip": {
-            "hideZeros": false,
-            "mode": "multi",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "11.5.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "expr": "100 - ((node_filesystem_avail_bytes{supabase_project_ref=\"$project\",device!~'rootfs'} * 100) / node_filesystem_size_bytes{supabase_project_ref=\"$project\",device!~'rootfs'})",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "Disk mounted at {{mountpoint}}",
-            "refId": "A",
-            "step": 240
-          }
-        ],
-        "title": "Disk Space Used, EBS IO Balance",
-        "type": "timeseries"
-      },
-      {
-        "collapsed": false,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 20
-        },
-        "id": 317,
-        "panels": [],
-        "title": "Postgres",
-        "type": "row"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "description": "Disk space used by the database",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisBorderShow": false,
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "axisSoftMax": 100,
-              "barAlignment": 0,
-              "barWidthFactor": 0.6,
-              "drawStyle": "line",
-              "fillOpacity": 40,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "insertNulls": false,
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "never",
-              "spanNulls": true,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "links": [],
-            "mappings": [],
-            "min": 0,
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                }
-              ]
-            },
-            "unit": "decmbytes"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 6,
-          "w": 12,
-          "x": 0,
-          "y": 21
-        },
-        "id": 321,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": true
-          },
-          "tooltip": {
-            "hideZeros": false,
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "11.5.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "pg_database_size_mb{supabase_project_ref=\"$project\"}",
-            "format": "time_series",
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "Database size",
-            "refId": "A",
-            "step": 240
-          }
-        ],
-        "title": "Database size ",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "description": "Active number of client connections",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisBorderShow": false,
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "axisSoftMax": 20,
-              "barAlignment": 0,
-              "barWidthFactor": 0.6,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "insertNulls": false,
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "never",
-              "spanNulls": true,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "links": [],
-            "mappings": [],
-            "min": 0,
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                }
-              ]
-            },
-            "unit": "none"
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "pgbouncer client connections waiting"
-              },
-              "properties": [
-                {
-                  "id": "custom.axisPlacement",
-                  "value": "right"
-                }
-              ]
-            }
-          ]
-        },
-        "gridPos": {
-          "h": 6,
-          "w": 9,
-          "x": 12,
-          "y": 21
-        },
-        "id": 323,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": true
-          },
-          "tooltip": {
-            "hideZeros": false,
-            "mode": "multi",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "11.5.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "pg_stat_database_num_backends{supabase_project_ref=\"$project\"}",
-            "format": "time_series",
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "postgres connections",
-            "refId": "A",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "sum(supavisor_connections_active{supabase_project_ref=\"$project\"})",
-            "format": "time_series",
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "supavisor connections",
-            "refId": "B",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "pgbouncer_used_clients{supabase_project_ref=\"$project\"}",
-            "format": "time_series",
-            "hide": false,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "pgbouncer connections",
-            "refId": "C",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "sum by (Name) (pgbouncer_pools_client_waiting_connections{supabase_project_ref=\"$project\"})",
-            "format": "time_series",
-            "hide": false,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "pgbouncer client connections waiting",
-            "refId": "D",
-            "step": 240
-          }
-        ],
-        "title": "Client connections",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [
-              {
-                "options": {
-                  "0": {
-                    "color": "red",
-                    "index": 1,
-                    "text": "Stopped"
-                  },
-                  "1": {
-                    "color": "green",
-                    "index": 0,
-                    "text": "Running"
-                  }
-                },
-                "type": "value"
-              }
-            ],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 0
-                },
-                {
-                  "color": "green",
-                  "value": 1
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 3,
-          "w": 3,
-          "x": 21,
-          "y": 21
-        },
-        "id": 319,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "none",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "percentChangeColorMode": "standard",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showPercentChange": false,
-          "text": {},
-          "textMode": "auto",
-          "wideLayout": true
-        },
-        "pluginVersion": "11.5.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "pg_up{supabase_project_ref=\"$project\"}",
-            "interval": "",
-            "legendFormat": "",
-            "refId": "A"
-          }
-        ],
-        "title": "Postgres status",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [
-              {
-                "options": {
-                  "0": {
-                    "color": "red",
-                    "index": 1,
-                    "text": "Stopped"
-                  },
-                  "1": {
-                    "color": "green",
-                    "index": 0,
-                    "text": "Running"
-                  }
-                },
-                "type": "value"
-              }
-            ],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 0
-                },
-                {
-                  "color": "green",
-                  "value": 1
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 3,
-          "w": 3,
-          "x": 21,
-          "y": 24
-        },
-        "id": 341,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "none",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "percentChangeColorMode": "standard",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showPercentChange": false,
-          "text": {},
-          "textMode": "auto",
-          "wideLayout": true
-        },
-        "pluginVersion": "11.5.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "pgbouncer_up{supabase_project_ref=\"$project\"}",
-            "interval": "",
-            "legendFormat": "",
-            "refId": "A"
-          }
-        ],
-        "title": "pgbouncer status",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "description": "",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisBorderShow": false,
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "axisSoftMax": 5,
-              "barAlignment": 0,
-              "barWidthFactor": 0.6,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "insertNulls": false,
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "never",
-              "spanNulls": true,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "links": [],
-            "mappings": [],
-            "min": 0,
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                }
-              ]
-            },
-            "unit": "none"
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Total time spent"
-              },
-              "properties": [
-                {
-                  "id": "custom.axisPlacement",
-                  "value": "right"
-                },
-                {
-                  "id": "unit",
-                  "value": "s"
-                },
-                {
-                  "id": "custom.axisSoftMax"
-                }
-              ]
-            }
-          ]
-        },
-        "gridPos": {
-          "h": 7,
-          "w": 7,
-          "x": 0,
-          "y": 27
-        },
-        "id": 330,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": true
-          },
-          "tooltip": {
-            "hideZeros": false,
-            "mode": "multi",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "11.5.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "rate(supabase_usage_metrics_user_queries_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-            "format": "time_series",
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "No. of user queries",
-            "refId": "A",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "rate(pg_stat_statements_total_queries{supabase_project_ref=\"$project\"}[$__rate_interval])",
-            "hide": false,
-            "interval": "",
-            "legendFormat": "Total no. of queries",
-            "refId": "B"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "rate(pg_stat_statements_total_time_seconds{supabase_project_ref=\"$project\"}[$__rate_interval])",
-            "format": "time_series",
-            "hide": false,
-            "interval": "",
-            "legendFormat": "Total time spent",
-            "refId": "C"
-          }
-        ],
-        "title": "Query stats",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "description": "",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisBorderShow": false,
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "axisSoftMax": 5,
-              "barAlignment": 0,
-              "barWidthFactor": 0.6,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "insertNulls": false,
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "never",
-              "spanNulls": true,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "links": [],
-            "mappings": [],
-            "min": 0,
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                }
-              ]
-            },
-            "unit": "none"
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Deadlocks detected"
-              },
-              "properties": [
-                {
-                  "id": "custom.axisPlacement",
-                  "value": "right"
-                },
-                {
-                  "id": "custom.axisSoftMax",
-                  "value": 25
-                }
-              ]
-            }
-          ]
-        },
-        "gridPos": {
-          "h": 7,
-          "w": 7,
-          "x": 7,
-          "y": 27
-        },
-        "id": 342,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": true
-          },
-          "tooltip": {
-            "hideZeros": false,
-            "mode": "multi",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "11.5.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "rate(pg_stat_database_xact_commit_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-            "format": "time_series",
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "Tx committed",
-            "refId": "A",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "rate(pg_stat_database_xact_rollback_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-            "format": "time_series",
-            "hide": false,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "Tx rolled back",
-            "refId": "B",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "rate(pg_stat_database_deadlocks_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-            "format": "time_series",
-            "hide": false,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "Deadlocks detected",
-            "refId": "C",
-            "step": 240
-          }
-        ],
-        "title": "pg stats",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "description": "",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisBorderShow": false,
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "axisSoftMax": 5,
-              "barAlignment": 0,
-              "barWidthFactor": 0.6,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "insertNulls": false,
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "never",
-              "spanNulls": true,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "links": [],
-            "mappings": [],
-            "min": 0,
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                }
-              ]
-            },
-            "unit": "none"
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Total time spent"
-              },
-              "properties": [
-                {
-                  "id": "custom.axisPlacement",
-                  "value": "right"
-                },
-                {
-                  "id": "unit",
-                  "value": "s"
-                },
-                {
-                  "id": "custom.axisSoftMax"
-                }
-              ]
-            }
-          ]
-        },
-        "gridPos": {
-          "h": 7,
-          "w": 7,
-          "x": 14,
-          "y": 27
-        },
-        "id": 331,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": true
-          },
-          "tooltip": {
-            "hideZeros": false,
-            "mode": "multi",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "11.5.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "rate(pg_stat_database_conflicts_confl_tablespace_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-            "format": "time_series",
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "Dropped tablespaces",
-            "refId": "A",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "rate(pg_stat_database_conflicts_confl_lock_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-            "format": "time_series",
-            "hide": false,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "Lock timeouts",
-            "refId": "B",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "rate(pg_stat_database_conflicts_confl_snapshot_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-            "format": "time_series",
-            "hide": false,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "Old Snapshots",
-            "refId": "C",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "rate(pg_stat_database_conflicts_confl_bufferpin_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-            "format": "time_series",
-            "hide": false,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "Pinned buffers",
-            "refId": "D",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "rate(pg_stat_database_conflicts_confl_deadlock_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-            "format": "time_series",
-            "hide": false,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "Deadlocks",
-            "refId": "E",
-            "step": 240
-          }
-        ],
-        "title": "Conflicts - Queries cancelled due to",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [
-              {
-                "options": {
-                  "0": {
-                    "color": "green",
-                    "index": 0,
-                    "text": "ReadWrite"
-                  },
-                  "1": {
-                    "color": "red",
-                    "index": 1,
-                    "text": "ReadOnly"
-                  }
-                },
-                "type": "value"
-              }
-            ],
-            "noValue": "N/A",
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "green",
-                  "value": 0
-                },
-                {
-                  "color": "red",
-                  "value": 1
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 3,
-          "w": 3,
-          "x": 21,
-          "y": 27
-        },
-        "id": 324,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "none",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "percentChangeColorMode": "standard",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "limit": 2,
-            "values": false
-          },
-          "showPercentChange": false,
-          "text": {},
-          "textMode": "auto",
-          "wideLayout": true
-        },
-        "pluginVersion": "11.5.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "pg_settings_default_transaction_read_only{supabase_project_ref=\"$project\"}",
-            "instant": false,
-            "interval": "",
-            "legendFormat": "",
-            "refId": "A"
-          }
-        ],
-        "title": "DB Mode",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [
-              {
-                "options": {
-                  "0": {
-                    "color": "green",
-                    "index": 0,
-                    "text": "No"
-                  },
-                  "1": {
-                    "color": "red",
-                    "index": 1,
-                    "text": "Yes"
-                  }
-                },
-                "type": "value"
-              }
-            ],
-            "noValue": "N/A",
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "green",
-                  "value": 0
-                },
-                {
-                  "color": "red",
-                  "value": 1
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 3,
-          "w": 3,
-          "x": 21,
-          "y": 30
-        },
-        "id": 325,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "none",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "percentChangeColorMode": "standard",
-          "reduceOptions": {
-            "calcs": [
-              "last"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showPercentChange": false,
-          "text": {},
-          "textMode": "auto",
-          "wideLayout": true
-        },
-        "pluginVersion": "11.5.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "pg_status_in_recovery{supabase_project_ref=\"$project\"}",
-            "interval": "",
-            "legendFormat": "",
-            "refId": "A"
-          }
-        ],
-        "title": "In Recovery",
-        "type": "stat"
-      },
-      {
-        "collapsed": false,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 34
-        },
-        "id": 337,
-        "panels": [],
-        "title": "Postgres: realtime",
-        "type": "row"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "description": "Realtime replication status",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [
-              {
-                "options": {
-                  "0": {
-                    "color": "red",
-                    "index": 1,
-                    "text": "Inactive"
-                  },
-                  "1": {
-                    "color": "green",
-                    "index": 0,
-                    "text": "Active"
-                  }
-                },
-                "type": "value"
-              }
-            ],
-            "noValue": "N/A",
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 0
-                },
-                {
-                  "color": "green",
-                  "value": 1
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 3,
-          "w": 3,
-          "x": 0,
-          "y": 35
-        },
-        "id": 328,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "none",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "percentChangeColorMode": "standard",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showPercentChange": false,
-          "text": {},
-          "textMode": "auto",
-          "wideLayout": true
-        },
-        "pluginVersion": "11.5.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "replication_realtime_slot_status{supabase_project_ref=\"$project\"}",
-            "interval": "",
-            "legendFormat": "",
-            "refId": "A"
-          }
-        ],
-        "title": "Realtime replication status",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "description": "",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisBorderShow": false,
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "axisSoftMax": 20,
-              "barAlignment": 0,
-              "barWidthFactor": 0.6,
-              "drawStyle": "line",
-              "fillOpacity": 40,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "insertNulls": false,
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "never",
-              "spanNulls": true,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "links": [],
-            "mappings": [],
-            "min": 0,
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                }
-              ]
-            },
-            "unit": "decbytes"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 3,
-          "w": 7,
-          "x": 3,
-          "y": 35
-        },
-        "id": 329,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": true
-          },
-          "tooltip": {
-            "hideZeros": false,
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "11.5.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "replication_realtime_lag_bytes{supabase_project_ref=\"$project\"}",
-            "format": "time_series",
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "Replication lag ",
-            "refId": "A",
-            "step": 240
-          }
-        ],
-        "title": "Realtime replication lag",
-        "type": "timeseries"
-      },
-      {
-        "collapsed": false,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 38
-        },
-        "id": 335,
-        "panels": [],
-        "title": "Postgres: bgwriter",
-        "type": "row"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "description": "",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "axisSoftMax": 5,
-              "barAlignment": 0,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "never",
-              "spanNulls": true,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "links": [],
-            "mappings": [],
-            "min": 0,
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green"
-                }
-              ]
-            },
-            "unit": "none"
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byRegexp",
-                "options": "/^Time spent/"
-              },
-              "properties": [
-                {
-                  "id": "custom.axisPlacement",
-                  "value": "right"
-                },
-                {
-                  "id": "unit",
-                  "value": "ms"
-                }
-              ]
-            }
-          ]
-        },
-        "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 0,
-          "y": 39
-        },
-        "id": 332,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom"
-          },
-          "tooltip": {
-            "mode": "multi"
-          }
-        },
-        "pluginVersion": "8.3.3",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "rate(pg_stat_bgwriter_checkpoints_timed_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-            "format": "time_series",
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "Scheduled checkpoints",
-            "refId": "A",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "rate(pg_stat_bgwriter_checkpoints_req_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-            "format": "time_series",
-            "hide": false,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "Requested checkpoints",
-            "refId": "B",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "rate(pg_stat_bgwriter_checkpoint_write_time_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-            "format": "time_series",
-            "hide": false,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "Time spent writing checkpoint files",
-            "refId": "C",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "rate(pg_stat_bgwriter_checkpoint_sync_time_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-            "format": "time_series",
-            "hide": false,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "Time spent synchronizing checkpoint files",
-            "refId": "D",
-            "step": 240
-          }
-        ],
-        "title": "bgwriter stats: checkpoints",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "description": "",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "axisSoftMax": 5,
-              "barAlignment": 0,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "never",
-              "spanNulls": true,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "links": [],
-            "mappings": [],
-            "min": 0,
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green"
-                }
-              ]
-            },
-            "unit": "none"
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Allocated"
-              },
-              "properties": [
-                {
-                  "id": "custom.axisPlacement",
-                  "value": "right"
-                }
-              ]
-            }
-          ]
-        },
-        "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 8,
-          "y": 39
-        },
-        "id": 333,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom"
-          },
-          "tooltip": {
-            "mode": "multi"
-          }
-        },
-        "pluginVersion": "8.3.3",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "rate(pg_stat_bgwriter_buffers_checkpoint_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-            "format": "time_series",
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "Written during checkpoints",
-            "refId": "A",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "rate(pg_stat_bgwriter_buffers_clean_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-            "format": "time_series",
-            "hide": false,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "Written by bgwriter",
-            "refId": "B",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "rate(pg_stat_bgwriter_buffers_backend_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-            "format": "time_series",
-            "hide": false,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "Written by a backend",
-            "refId": "C",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "rate(pg_stat_bgwriter_buffers_alloc_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-            "format": "time_series",
-            "hide": false,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "Allocated",
-            "refId": "D",
-            "step": 240
-          }
-        ],
-        "title": "bgwriter stats: buffers",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "description": "",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "axisSoftMax": 5,
-              "barAlignment": 0,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "never",
-              "spanNulls": true,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "links": [],
-            "mappings": [],
-            "min": 0,
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green"
-                }
-              ]
-            },
-            "unit": "none"
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Backend fsync calls"
-              },
-              "properties": [
-                {
-                  "id": "custom.axisPlacement",
-                  "value": "right"
-                }
-              ]
-            }
-          ]
-        },
-        "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 16,
-          "y": 39
-        },
-        "id": 340,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom"
-          },
-          "tooltip": {
-            "mode": "multi"
-          }
-        },
-        "pluginVersion": "8.3.3",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "rate(pg_stat_bgwriter_maxwritten_clean_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-            "format": "time_series",
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "No. of times clean stopped due to writing too many buffers",
-            "refId": "A",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "exemplar": false,
-            "expr": "rate(pg_stat_bgwriter_buffers_backend_fsync_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-            "format": "time_series",
-            "hide": false,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "Fsync calls by backend",
-            "refId": "D",
-            "step": 240
-          }
-        ],
-        "title": "bgwriter: fsync/clean",
-        "type": "timeseries"
-      },
-      {
-        "collapsed": true,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 46
-        },
-        "id": 265,
-        "panels": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "description": "",
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 12,
-              "w": 12,
-              "x": 0,
-              "y": 3
-            },
-            "id": 3,
-            "maxPerRow": 6,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode=\"system\",supabase_project_ref=\"$project\"}[$__rate_interval])) * 100",
-                "format": "time_series",
-                "interval": "10s",
-                "intervalFactor": 1,
-                "legendFormat": "System - Processes executing in kernel mode",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='user',supabase_project_ref=\"$project\"}[$__rate_interval])) * 100",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "User - Normal processes executing in user mode",
-                "refId": "B",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='nice',supabase_project_ref=\"$project\"}[$__rate_interval])) * 100",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "Nice - Niced processes executing in user mode",
-                "refId": "C",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='idle',supabase_project_ref=\"$project\"}[$__rate_interval])) * 100",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "Idle - Waiting for something to happen",
-                "refId": "D",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='iowait',supabase_project_ref=\"$project\"}[$__rate_interval])) * 100",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "Iowait - Waiting for I/O to complete",
-                "refId": "E",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='irq',supabase_project_ref=\"$project\"}[$__rate_interval])) * 100",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "Irq - Servicing interrupts",
-                "refId": "F",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='softirq',supabase_project_ref=\"$project\"}[$__rate_interval])) * 100",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "Softirq - Servicing softirqs",
-                "refId": "G",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='steal',supabase_project_ref=\"$project\"}[$__rate_interval])) * 100",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "Steal - Time spent in other operating systems when running in a virtualized environment",
-                "refId": "H",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='guest',supabase_project_ref=\"$project\"}[$__rate_interval])) * 100",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "Guest - Time spent running a virtual CPU for a guest operating system",
-                "refId": "I",
-                "step": 240
-              }
-            ],
-            "title": "CPU",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "description": "",
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 12,
-              "w": 12,
-              "x": 12,
-              "y": 3
-            },
-            "id": 24,
-            "maxPerRow": 6,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_MemTotal_bytes{supabase_project_ref=\"$project\"} - node_memory_MemFree_bytes{supabase_project_ref=\"$project\"} - node_memory_Buffers_bytes{supabase_project_ref=\"$project\"} - node_memory_Cached_bytes{supabase_project_ref=\"$project\"} - node_memory_Slab_bytes{supabase_project_ref=\"$project\"} - node_memory_PageTables_bytes{supabase_project_ref=\"$project\"} - node_memory_SwapCached_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "hide": false,
-                "intervalFactor": 1,
-                "legendFormat": "Apps - Memory used by user-space applications",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_PageTables_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "hide": false,
-                "intervalFactor": 1,
-                "legendFormat": "PageTables - Memory used to map between virtual and physical memory addresses",
-                "refId": "B",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_SwapCached_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "SwapCache - Memory that keeps track of pages that have been fetched from swap but not yet been modified",
-                "refId": "C",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_Slab_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "hide": false,
-                "intervalFactor": 1,
-                "legendFormat": "Slab - Memory used by the kernel to cache data structures for its own use (caches like inode, dentry, etc)",
-                "refId": "D",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_Cached_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "hide": false,
-                "intervalFactor": 1,
-                "legendFormat": "Cache - Parked file data (file content) cache",
-                "refId": "E",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_Buffers_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "hide": false,
-                "intervalFactor": 1,
-                "legendFormat": "Buffers - Block device (e.g. harddisk) cache",
-                "refId": "F",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_MemFree_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "hide": false,
-                "intervalFactor": 1,
-                "legendFormat": "Unused - Free memory unassigned",
-                "refId": "G",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "(node_memory_SwapTotal_bytes{supabase_project_ref=\"$project\"} - node_memory_SwapFree_bytes{supabase_project_ref=\"$project\"})",
-                "format": "time_series",
-                "hide": false,
-                "intervalFactor": 1,
-                "legendFormat": "Swap - Swap space used",
-                "refId": "H",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_HardwareCorrupted_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "hide": false,
-                "intervalFactor": 1,
-                "legendFormat": "Hardware Corrupted - Amount of RAM that the kernel identified as corrupted / not working",
-                "refId": "I",
-                "step": 240
-              }
-            ],
-            "title": "Memory Stack",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 12,
-              "w": 12,
-              "x": 0,
-              "y": 15
-            },
-            "id": 84,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_network_receive_bytes_total{supabase_project_ref=\"$project\"}[$__rate_interval])*8",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "{{device}} - Receive",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_network_transmit_bytes_total{supabase_project_ref=\"$project\"}[$__rate_interval])*8",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "{{device}} - Transmit",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "Network Traffic",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "description": "",
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 12,
-              "w": 12,
-              "x": 12,
-              "y": 15
-            },
-            "id": 156,
-            "maxPerRow": 6,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_filesystem_size_bytes{supabase_project_ref=\"$project\",device!~'rootfs'} - node_filesystem_avail_bytes{supabase_project_ref=\"$project\",device!~'rootfs'}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "{{mountpoint}}",
-                "refId": "A",
-                "step": 240
-              }
-            ],
-            "title": "Disk Space Used",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "description": "",
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 12,
-              "w": 12,
-              "x": 0,
-              "y": 27
-            },
-            "id": 229,
-            "maxPerRow": 6,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_disk_reads_completed_total{supabase_project_ref=\"$project\",device=~\"$diskdevices\"}[$__rate_interval])",
-                "intervalFactor": 1,
-                "legendFormat": "{{device}} - Reads completed",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_disk_writes_completed_total{supabase_project_ref=\"$project\",device=~\"$diskdevices\"}[$__rate_interval])",
-                "intervalFactor": 1,
-                "legendFormat": "{{device}} - Writes completed",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "Disk IOps",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "description": "",
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 12,
-              "w": 12,
-              "x": 12,
-              "y": 27
-            },
-            "id": 42,
-            "maxPerRow": 6,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_disk_read_bytes_total{supabase_project_ref=\"$project\",device=~\"$diskdevices\"}[$__rate_interval])",
-                "format": "time_series",
-                "hide": false,
-                "intervalFactor": 1,
-                "legendFormat": "{{device}} - Successfully read bytes",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_disk_written_bytes_total{supabase_project_ref=\"$project\",device=~\"$diskdevices\"}[$__rate_interval])",
-                "format": "time_series",
-                "hide": false,
-                "intervalFactor": 1,
-                "legendFormat": "{{device}} - Successfully written bytes",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "I/O Usage Read / Write",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "description": "",
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 12,
-              "w": 12,
-              "x": 0,
-              "y": 39
-            },
-            "id": 127,
-            "maxPerRow": 6,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_disk_io_time_seconds_total{supabase_project_ref=\"$project\",device=~\"$diskdevices\"} [$__rate_interval])",
-                "format": "time_series",
-                "hide": false,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "{{device}}",
-                "refId": "A",
-                "step": 240
-              }
-            ],
-            "title": "I/O Utilization",
-            "type": "timeseries"
-          }
-        ],
-        "title": "CPU / Memory / Net / Disk",
-        "type": "row"
-      },
-      {
-        "collapsed": true,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 47
-        },
-        "id": 266,
-        "panels": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 70
-            },
-            "id": 136,
-            "maxPerRow": 2,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_Inactive_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "Inactive - Memory which has been less recently used.  It is more eligible to be reclaimed for other purposes",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_Active_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "Active - Memory that has been used more recently and usually not reclaimed unless absolutely necessary",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "Memory Active / Inactive",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 70
-            },
-            "id": 135,
-            "maxPerRow": 6,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_Committed_AS_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "Committed_AS - Amount of memory presently allocated on the system",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_CommitLimit_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "CommitLimit - Amount of  memory currently available to be allocated on the system",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "Memory Commited",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 80
-            },
-            "id": 191,
-            "maxPerRow": 6,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_Inactive_file_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "hide": false,
-                "intervalFactor": 1,
-                "legendFormat": "Inactive_file - File-backed memory on inactive LRU list",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_Inactive_anon_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "hide": false,
-                "intervalFactor": 1,
-                "legendFormat": "Inactive_anon - Anonymous and swap cache on inactive LRU list, including tmpfs (shmem)",
-                "refId": "B",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_Active_file_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "hide": false,
-                "intervalFactor": 1,
-                "legendFormat": "Active_file - File-backed memory on active LRU list",
-                "refId": "C",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_Active_anon_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "hide": false,
-                "intervalFactor": 1,
-                "legendFormat": "Active_anon - Anonymous and swap cache on active least-recently-used (LRU) list, including tmpfs",
-                "refId": "D",
-                "step": 240
-              }
-            ],
-            "title": "Memory Active / Inactive Detail",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 80
-            },
-            "id": 130,
-            "maxPerRow": 2,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_Writeback_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "Writeback - Memory which is actively being written back to disk",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_WritebackTmp_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "WritebackTmp - Memory used by FUSE for temporary writeback buffers",
-                "refId": "B",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_Dirty_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "Dirty - Memory which is waiting to get written back to the disk",
-                "refId": "C",
-                "step": 240
-              }
-            ],
-            "title": "Memory Writeback and Dirty",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 90
-            },
-            "id": 138,
-            "maxPerRow": 6,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_Mapped_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "Mapped - Used memory in mapped pages files which have been mmaped, such as libraries",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_Shmem_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "Shmem - Used shared memory (shared between several processes, thus including RAM disks)",
-                "refId": "B",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_ShmemHugePages_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "ShmemHugePages - Memory used by shared memory (shmem) and tmpfs allocated  with huge pages",
-                "refId": "C",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_ShmemPmdMapped_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "ShmemPmdMapped - Ammount of shared (shmem/tmpfs) memory backed by huge pages",
-                "refId": "D",
-                "step": 240
-              }
-            ],
-            "title": "Memory Shared and Mapped",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 90
-            },
-            "id": 131,
-            "maxPerRow": 2,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_SUnreclaim_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "SUnreclaim - Part of Slab, that cannot be reclaimed on memory pressure",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_SReclaimable_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "SReclaimable - Part of Slab, that might be reclaimed, such as caches",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "Memory Slab",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 100
-            },
-            "id": 70,
-            "maxPerRow": 6,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_VmallocChunk_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "hide": false,
-                "intervalFactor": 1,
-                "legendFormat": "VmallocChunk - Largest contigious block of vmalloc area which is free",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_VmallocTotal_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "hide": false,
-                "intervalFactor": 1,
-                "legendFormat": "VmallocTotal - Total size of vmalloc memory area",
-                "refId": "B",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_VmallocUsed_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "hide": false,
-                "intervalFactor": 1,
-                "legendFormat": "VmallocUsed - Amount of vmalloc area which is used",
-                "refId": "C",
-                "step": 240
-              }
-            ],
-            "title": "Memory Vmalloc",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 100
-            },
-            "id": 159,
-            "maxPerRow": 6,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_Bounce_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "Bounce - Memory used for block device bounce buffers",
-                "refId": "A",
-                "step": 240
-              }
-            ],
-            "title": "Memory Bounce",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 110
-            },
-            "id": 129,
-            "maxPerRow": 6,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_AnonHugePages_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "AnonHugePages - Memory in anonymous huge pages",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_AnonPages_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "AnonPages - Memory in user pages not backed by files",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "Memory Anonymous",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 110
-            },
-            "id": 160,
-            "maxPerRow": 2,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_KernelStack_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "KernelStack - Kernel memory stack. This is not reclaimable",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_Percpu_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "PerCPU - Per CPU memory allocated dynamically by loadable modules",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "Memory Kernel / CPU",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 120
-            },
-            "id": 140,
-            "maxPerRow": 6,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_HugePages_Free{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "HugePages_Free - Huge pages in the pool that are not yet allocated",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_HugePages_Rsvd{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "HugePages_Rsvd - Huge pages for which a commitment to allocate from the pool has been made, but no allocation has yet been made",
-                "refId": "B",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_HugePages_Surp{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "HugePages_Surp - Huge pages in the pool above the value in /proc/sys/vm/nr_hugepages",
-                "refId": "C",
-                "step": 240
-              }
-            ],
-            "title": "Memory HugePages Counter",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 120
-            },
-            "id": 71,
-            "maxPerRow": 2,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_HugePages_Total{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "HugePages - Total size of the pool of huge pages",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_Hugepagesize_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "Hugepagesize - Huge Page size",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "Memory HugePages Size",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 130
-            },
-            "id": 128,
-            "maxPerRow": 6,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_DirectMap1G_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "DirectMap1G - Amount of pages mapped as this size",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_DirectMap2M_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "DirectMap2M - Amount of pages mapped as this size",
-                "refId": "B",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_DirectMap4k_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "DirectMap4K - Amount of pages mapped as this size",
-                "refId": "C",
-                "step": 240
-              }
-            ],
-            "title": "Memory DirectMap",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 130
-            },
-            "id": 137,
-            "maxPerRow": 6,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_Unevictable_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "Unevictable - Amount of unevictable memory that can't be swapped out for a variety of reasons",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_Mlocked_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "MLocked - Size of pages locked to memory using the mlock() system call",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "Memory Unevictable and MLocked",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 140
-            },
-            "id": 132,
-            "maxPerRow": 6,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_memory_NFS_Unstable_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "NFS Unstable - Memory in NFS pages sent to the server, but not yet commited to the storage",
-                "refId": "A",
-                "step": 240
-              }
-            ],
-            "title": "Memory NFS",
-            "type": "timeseries"
-          }
-        ],
-        "title": "Memory Meminfo",
-        "type": "row"
-      },
-      {
-        "collapsed": true,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 48
-        },
-        "id": 267,
-        "panels": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 23
-            },
-            "id": 176,
-            "maxPerRow": 6,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_vmstat_pgpgin{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "Pagesin - Page in operations",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_vmstat_pgpgout{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "Pagesout - Page out operations",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "Memory Pages In / Out",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 23
-            },
-            "id": 22,
-            "maxPerRow": 6,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_vmstat_pswpin{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "Pswpin - Pages swapped in",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_vmstat_pswpout{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "Pswpout - Pages swapped out",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "Memory Pages Swap In / Out",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 33
-            },
-            "id": 175,
-            "maxPerRow": 6,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_vmstat_pgfault{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "Pgfault - Page major and minor fault operations",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_vmstat_pgmajfault{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "Pgmajfault - Major page fault operations",
-                "refId": "B",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_vmstat_pgfault{supabase_project_ref=\"$project\"}[$__rate_interval])  - rate(node_vmstat_pgmajfault{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "Pgminfault - Minor page fault operations",
-                "refId": "C",
-                "step": 240
-              }
-            ],
-            "title": "Memory Page Faults",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 33
-            },
-            "id": 307,
-            "maxPerRow": 6,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_vmstat_oom_kill{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "oom killer invocations ",
-                "refId": "A",
-                "step": 240
-              }
-            ],
-            "title": "OOM Killer",
-            "type": "timeseries"
-          }
-        ],
-        "title": "Memory Vmstat",
-        "type": "row"
-      },
-      {
-        "collapsed": true,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 49
-        },
-        "id": 293,
-        "panels": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "description": "",
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 24
-            },
-            "id": 260,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_timex_estimated_error_seconds{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "hide": false,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Estimated error in seconds",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_timex_offset_seconds{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "hide": false,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Time offset in between local system and reference clock",
-                "refId": "B",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_timex_maxerror_seconds{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "hide": false,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Maximum error in seconds",
-                "refId": "C",
-                "step": 240
-              }
-            ],
-            "title": "Time Syncronized Drift",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "description": "",
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 24
-            },
-            "id": 291,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_timex_loop_time_constant{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Phase-locked loop time adjust",
-                "refId": "A",
-                "step": 240
-              }
-            ],
-            "title": "Time PLL Adjust",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "description": "",
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 34
-            },
-            "id": 168,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_timex_sync_status{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Is clock synchronized to a reliable server (1 = yes, 0 = no)",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_timex_frequency_adjustment_ratio{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Local clock frequency adjustment",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "Time Syncronized Status",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "description": "",
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 34
-            },
-            "id": 294,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_timex_tick_seconds{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Seconds between clock ticks",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_timex_tai_offset_seconds{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "International Atomic Time (TAI) offset",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "Time Misc",
-            "type": "timeseries"
-          }
-        ],
-        "title": "System Timesync",
-        "type": "row"
-      },
-      {
-        "collapsed": true,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 50
-        },
-        "id": 312,
-        "panels": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 7
-            },
-            "id": 62,
-            "maxPerRow": 6,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_procs_blocked{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "Processes blocked waiting for I/O to complete",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_procs_running{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "Processes in runnable state",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "Processes Status",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 7
-            },
-            "id": 315,
-            "maxPerRow": 6,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_processes_state{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "{{ state }}",
-                "refId": "A",
-                "step": 240
-              }
-            ],
-            "title": "Processes State",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 17
-            },
-            "id": 148,
-            "maxPerRow": 6,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_forks_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "hide": false,
-                "intervalFactor": 1,
-                "legendFormat": "Processes forks second",
-                "refId": "A",
-                "step": 240
-              }
-            ],
-            "title": "Processes  Forks",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 17
-            },
-            "id": 149,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(process_virtual_memory_bytes{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "hide": false,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Processes virtual memory size in bytes",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "process_resident_memory_max_bytes{supabase_project_ref=\"$project\"}",
-                "hide": false,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Maximum amount of virtual memory available in bytes",
-                "refId": "B",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(process_virtual_memory_bytes{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "hide": false,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Processes virtual memory size in bytes",
-                "refId": "C",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(process_virtual_memory_max_bytes{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "hide": false,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Maximum amount of virtual memory available in bytes",
-                "refId": "D",
-                "step": 240
-              }
-            ],
-            "title": "Processes Memory",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 27
-            },
-            "id": 313,
-            "maxPerRow": 6,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_processes_pids{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Number of PIDs",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_processes_max_processes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "PIDs limit",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "PIDs Number and Limit",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 27
-            },
-            "id": 305,
-            "maxPerRow": 6,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_schedstat_running_seconds_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "CPU {{ cpu }} - seconds spent running a process",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_schedstat_waiting_seconds_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "CPU {{ cpu }} - seconds spent by processing waiting for this CPU",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "Process schedule stats Running / Waiting",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 37
-            },
-            "id": 314,
-            "maxPerRow": 6,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_processes_threads{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Allocated threads",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_processes_max_threads{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Threads limit",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "Threads Number and Limit",
-            "type": "timeseries"
-          }
-        ],
-        "title": "System Processes",
-        "type": "row"
-      },
-      {
-        "collapsed": true,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 51
-        },
-        "id": 269,
-        "panels": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 8
-            },
-            "id": 8,
-            "maxPerRow": 6,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_context_switches_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "Context switches",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_intr_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "hide": false,
-                "intervalFactor": 1,
-                "legendFormat": "Interrupts",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "Context Switches / Interrupts",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 8
-            },
-            "id": 7,
-            "maxPerRow": 6,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_load1{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "Load 1m",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_load5{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "Load 5m",
-                "refId": "B",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_load15{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "Load 15m",
-                "refId": "C",
-                "step": 240
-              }
-            ],
-            "title": "System Load",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 18
-            },
-            "id": 259,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_interrupts_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "{{ type }} - {{ info }}",
-                "refId": "A",
-                "step": 240
-              }
-            ],
-            "title": "Interrupts Detail",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 18
-            },
-            "id": 306,
-            "maxPerRow": 6,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_schedstat_timeslices_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "CPU {{ cpu }}",
-                "refId": "A",
-                "step": 240
-              }
-            ],
-            "title": "Schedule timeslices executed by each cpu",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 28
-            },
-            "id": 151,
-            "maxPerRow": 6,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_entropy_available_bits{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "Entropy available to random number generators",
-                "refId": "A",
-                "step": 240
-              }
-            ],
-            "title": "Entropy",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 28
-            },
-            "id": 308,
-            "maxPerRow": 6,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(process_cpu_seconds_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Time spent",
-                "refId": "A",
-                "step": 240
-              }
-            ],
-            "title": "CPU time spent in user and system contexts",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 38
-            },
-            "id": 64,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "process_max_fds{supabase_project_ref=\"$project\"}",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Maximum open file descriptors",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "process_open_fds{supabase_project_ref=\"$project\"}",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Open file descriptors",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "File Descriptors",
-            "type": "timeseries"
-          }
-        ],
-        "title": "System Misc",
-        "type": "row"
-      },
-      {
-        "collapsed": true,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 52
-        },
-        "id": 304,
-        "panels": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 26
-            },
-            "id": 158,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_hwmon_temp_celsius{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "{{ chip }} {{ sensor }} temp",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_hwmon_temp_crit_alarm_celsius{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "hide": true,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "{{ chip }} {{ sensor }} Critical Alarm",
-                "refId": "B",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_hwmon_temp_crit_celsius{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "{{ chip }} {{ sensor }} Critical",
-                "refId": "C",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_hwmon_temp_crit_hyst_celsius{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "hide": true,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "{{ chip }} {{ sensor }} Critical Historical",
-                "refId": "D",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_hwmon_temp_max_celsius{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "hide": true,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "{{ chip }} {{ sensor }} Max",
-                "refId": "E",
-                "step": 240
-              }
-            ],
-            "title": "Hardware temperature monitor",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 26
-            },
-            "id": 300,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_cooling_device_cur_state{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "hide": false,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Current {{ name }} in {{ type }}",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_cooling_device_max_state{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Max {{ name }} in {{ type }}",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "Throttle cooling device",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 36
-            },
-            "id": 302,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_power_supply_online{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "hide": false,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "{{ power_supply }} online",
-                "refId": "A",
-                "step": 240
-              }
-            ],
-            "title": "Power supply",
-            "type": "timeseries"
-          }
-        ],
-        "title": "Hardware Misc",
-        "type": "row"
-      },
-      {
-        "collapsed": true,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 53
-        },
-        "id": 296,
-        "panels": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 10
-            },
-            "id": 297,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_systemd_socket_accepted_connections_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "{{ name }} Connections",
-                "refId": "A",
-                "step": 240
-              }
-            ],
-            "title": "Systemd Sockets",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 10
-            },
-            "id": 298,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_systemd_units{supabase_project_ref=\"$project\",state=\"activating\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Activating",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_systemd_units{supabase_project_ref=\"$project\",state=\"active\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Active",
-                "refId": "B",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_systemd_units{supabase_project_ref=\"$project\",state=\"deactivating\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Deactivating",
-                "refId": "C",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_systemd_units{supabase_project_ref=\"$project\",state=\"failed\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Failed",
-                "refId": "D",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_systemd_units{supabase_project_ref=\"$project\",state=\"inactive\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Inactive",
-                "refId": "E",
-                "step": 240
-              }
-            ],
-            "title": "Systemd Units State",
-            "type": "timeseries"
-          }
-        ],
-        "title": "Systemd",
-        "type": "row"
-      },
-      {
-        "collapsed": true,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 54
-        },
-        "id": 270,
-        "panels": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "description": "The number (after merges) of I/O requests completed per second for the device",
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 11
-            },
-            "id": 9,
-            "maxPerRow": 6,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_disk_reads_completed_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "intervalFactor": 1,
-                "legendFormat": "{{device}} - Reads completed",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_disk_writes_completed_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "intervalFactor": 1,
-                "legendFormat": "{{device}} - Writes completed",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "Disk IOps Completed",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "description": "The number of bytes read from or written to the device per second",
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 11
-            },
-            "id": 33,
-            "maxPerRow": 6,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_disk_read_bytes_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "{{device}} - Read bytes",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_disk_written_bytes_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "{{device}} - Written bytes",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "Disk R/W Data",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "description": "The average time for requests issued to the device to be served. This includes the time spent by the requests in queue and the time spent servicing them.",
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 21
-            },
-            "id": 37,
-            "maxPerRow": 6,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_disk_read_time_seconds_total{supabase_project_ref=\"$project\"}[$__rate_interval]) / rate(node_disk_reads_completed_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "hide": false,
-                "interval": "",
-                "intervalFactor": 4,
-                "legendFormat": "{{device}} - Read wait time avg",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_disk_write_time_seconds_total{supabase_project_ref=\"$project\"}[$__rate_interval]) / rate(node_disk_writes_completed_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "hide": false,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "{{device}} - Write wait time avg",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "Disk Average Wait Time",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "description": "The average queue length of the requests that were issued to the device",
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 21
-            },
-            "id": 35,
-            "maxPerRow": 6,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_disk_io_time_weighted_seconds_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "{{device}}",
-                "refId": "A",
-                "step": 240
-              }
-            ],
-            "title": "Average Queue Size",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "description": "The number of read and write requests merged per second that were queued to the device",
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 31
-            },
-            "id": 133,
-            "maxPerRow": 6,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_disk_reads_merged_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "intervalFactor": 1,
-                "legendFormat": "{{device}} - Read merged",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_disk_writes_merged_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "intervalFactor": 1,
-                "legendFormat": "{{device}} - Write merged",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "Disk R/W Merged",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "description": "Percentage of elapsed time during which I/O requests were issued to the device (bandwidth utilization for the device). Device saturation occurs when this value is close to 100% for devices serving requests serially.  But for devices  serving requests in parallel, such as RAID arrays and modern SSDs, this number does not reflect their performance limits.",
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 31
-            },
-            "id": 36,
-            "maxPerRow": 6,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_disk_io_time_seconds_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "{{device}} - IO",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_disk_discard_time_seconds_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "{{device}} - discard",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "Time Spent Doing I/Os",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "description": "The number of outstanding requests at the instant the sample was taken. Incremented as requests are given to appropriate struct request_queue and decremented as they finish.",
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 41
-            },
-            "id": 34,
-            "maxPerRow": 6,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_disk_io_now{supabase_project_ref=\"$project\"})",
-                "interval": "",
-                "intervalFactor": 4,
-                "legendFormat": "{{device}} - IO now",
-                "refId": "A",
-                "step": 240
-              }
-            ],
-            "title": "Instantaneous Queue Size",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "description": "",
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 41
-            },
-            "id": 301,
-            "maxPerRow": 6,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_disk_discards_completed_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "{{device}} - Discards completed",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_disk_discards_merged_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "{{device}} - Discards merged",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "Disk IOps Discards completed / merged",
-            "type": "timeseries"
-          }
-        ],
-        "title": "Storage Disk",
-        "type": "row"
-      },
-      {
-        "collapsed": true,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 55
-        },
-        "id": 271,
-        "panels": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "description": "",
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 12
-            },
-            "id": 43,
-            "maxPerRow": 6,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_filesystem_avail_bytes{supabase_project_ref=\"$project\",device!~'rootfs'}",
-                "format": "time_series",
-                "hide": false,
-                "intervalFactor": 1,
-                "legendFormat": "{{mountpoint}} - Available",
-                "metric": "",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_filesystem_free_bytes{supabase_project_ref=\"$project\",device!~'rootfs'}",
-                "format": "time_series",
-                "hide": true,
-                "intervalFactor": 1,
-                "legendFormat": "{{mountpoint}} - Free",
-                "refId": "B",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_filesystem_size_bytes{supabase_project_ref=\"$project\",device!~'rootfs'}",
-                "format": "time_series",
-                "hide": true,
-                "intervalFactor": 1,
-                "legendFormat": "{{mountpoint}} - Size",
-                "refId": "C",
-                "step": 240
-              }
-            ],
-            "title": "Filesystem space available",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "description": "",
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 12
-            },
-            "id": 41,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_filesystem_files_free{supabase_project_ref=\"$project\",device!~'rootfs'}",
-                "format": "time_series",
-                "hide": false,
-                "intervalFactor": 1,
-                "legendFormat": "{{mountpoint}} - Free file nodes",
-                "refId": "A",
-                "step": 240
-              }
-            ],
-            "title": "File Nodes Free",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "description": "",
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 22
-            },
-            "id": 28,
-            "maxPerRow": 6,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_filefd_maximum{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "Max open files",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_filefd_allocated{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "Open files",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "File Descriptor",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "description": "",
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 22
-            },
-            "id": 219,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_filesystem_files{supabase_project_ref=\"$project\",device!~'rootfs'}",
-                "format": "time_series",
-                "hide": false,
-                "intervalFactor": 1,
-                "legendFormat": "{{mountpoint}} - File nodes total",
-                "refId": "A",
-                "step": 240
-              }
-            ],
-            "title": "File Nodes Size",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "description": "",
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 32
-            },
-            "id": 44,
-            "maxPerRow": 6,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_filesystem_readonly{supabase_project_ref=\"$project\",device!~'rootfs'}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "{{mountpoint}} - ReadOnly",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_filesystem_device_error{supabase_project_ref=\"$project\",device!~'rootfs',fstype!~'tmpfs'}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "{{mountpoint}} - Device error",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "Filesystem in ReadOnly / Error",
-            "type": "timeseries"
-          }
-        ],
-        "title": "Storage Filesystem",
-        "type": "row"
-      },
-      {
-        "collapsed": true,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 56
-        },
-        "id": 272,
-        "panels": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 30
-            },
-            "id": 60,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_network_receive_packets_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "{{device}} - Receive",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_network_transmit_packets_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "{{device}} - Transmit",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "Network Traffic by Packets",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 30
-            },
-            "id": 142,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_network_receive_errs_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "{{device}} - Receive errors",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_network_transmit_errs_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "{{device}} - Rransmit errors",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "Network Traffic Errors",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 40
-            },
-            "id": 143,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_network_receive_drop_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "{{device}} - Receive drop",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_network_transmit_drop_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "{{device}} - Transmit drop",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "Network Traffic Drop",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 40
-            },
-            "id": 141,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_network_receive_compressed_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "{{device}} - Receive compressed",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_network_transmit_compressed_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "{{device}} - Transmit compressed",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "Network Traffic Compressed",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 50
-            },
-            "id": 146,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_network_receive_multicast_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "{{device}} - Receive multicast",
-                "refId": "A",
-                "step": 240
-              }
-            ],
-            "title": "Network Traffic Multicast",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 50
-            },
-            "id": 144,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_network_receive_fifo_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "{{device}} - Receive fifo",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_network_transmit_fifo_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "{{device}} - Transmit fifo",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "Network Traffic Fifo",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 60
-            },
-            "id": 145,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_network_receive_frame_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "hide": false,
-                "intervalFactor": 1,
-                "legendFormat": "{{device}} - Receive frame",
-                "refId": "A",
-                "step": 240
-              }
-            ],
-            "title": "Network Traffic Frame",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 60
-            },
-            "id": 231,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_network_transmit_carrier_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "{{device}} - Statistic transmit_carrier",
-                "refId": "A",
-                "step": 240
-              }
-            ],
-            "title": "Network Traffic Carrier",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 70
-            },
-            "id": 232,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_network_transmit_colls_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "{{device}} - Transmit colls",
-                "refId": "A",
-                "step": 240
-              }
-            ],
-            "title": "Network Traffic Colls",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 70
-            },
-            "id": 61,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_nf_conntrack_entries{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "NF conntrack entries",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_nf_conntrack_entries_limit{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "NF conntrack limit",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "NF Contrack",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 80
-            },
-            "id": 230,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_arp_entries{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "{{ device }} - ARP entries",
-                "refId": "A",
-                "step": 240
-              }
-            ],
-            "title": "ARP Entries",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 80
-            },
-            "id": 288,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_network_mtu_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "{{ device }} - Bytes",
-                "refId": "A",
-                "step": 240
-              }
-            ],
-            "title": "MTU",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 90
-            },
-            "id": 280,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_network_speed_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "{{ device }} - Speed",
-                "refId": "A",
-                "step": 240
-              }
-            ],
-            "title": "Speed",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 90
-            },
-            "id": 289,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_network_transmit_queue_length{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "{{ device }} -   Interface transmit queue length",
-                "refId": "A",
-                "step": 240
-              }
-            ],
-            "title": "Queue Length",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 100
-            },
-            "id": 290,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_softnet_processed_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "CPU {{cpu}} - Processed",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_softnet_dropped_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "CPU {{cpu}} - Dropped",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "Softnet Packets",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 100
-            },
-            "id": 310,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_softnet_times_squeezed_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "CPU {{cpu}} - Squeezed",
-                "refId": "A",
-                "step": 240
-              }
-            ],
-            "title": "Softnet Out of Quota",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 110
-            },
-            "id": 309,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_network_up{operstate=\"up\",supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "{{interface}} - Operational state UP",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_network_carrier{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "instant": false,
-                "legendFormat": "{{device}} - Physical link state",
-                "refId": "B"
-              }
-            ],
-            "title": "Network Operational Status",
-            "type": "timeseries"
-          }
-        ],
-        "title": "Network Traffic",
-        "type": "row"
-      },
-      {
-        "collapsed": true,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 57
-        },
-        "id": 273,
-        "panels": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 32
-            },
-            "id": 63,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_sockstat_TCP_alloc{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "TCP_alloc - Allocated sockets",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_sockstat_TCP_inuse{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "TCP_inuse - Tcp sockets currently in use",
-                "refId": "B",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_sockstat_TCP_mem{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "hide": true,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "TCP_mem - Used memory for tcp",
-                "refId": "C",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_sockstat_TCP_orphan{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "TCP_orphan - Orphan sockets",
-                "refId": "D",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_sockstat_TCP_tw{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "TCP_tw - Sockets wating close",
-                "refId": "E",
-                "step": 240
-              }
-            ],
-            "title": "Sockstat TCP",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 32
-            },
-            "id": 124,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_sockstat_UDPLITE_inuse{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "UDPLITE_inuse - Udplite sockets currently in use",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_sockstat_UDP_inuse{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "UDP_inuse - Udp sockets currently in use",
-                "refId": "B",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_sockstat_UDP_mem{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "UDP_mem - Used memory for udp",
-                "refId": "C",
-                "step": 240
-              }
-            ],
-            "title": "Sockstat UDP",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 42
-            },
-            "id": 125,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_sockstat_FRAG_inuse{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "FRAG_inuse - Frag sockets currently in use",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_sockstat_RAW_inuse{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "RAW_inuse - Raw sockets currently in use",
-                "refId": "C",
-                "step": 240
-              }
-            ],
-            "title": "Sockstat FRAG / RAW",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 42
-            },
-            "id": 220,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_sockstat_TCP_mem_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "mem_bytes - TCP sockets in that state",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_sockstat_UDP_mem_bytes{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "mem_bytes - UDP sockets in that state",
-                "refId": "B",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_sockstat_FRAG_memory{supabase_project_ref=\"$project\"}",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "FRAG_memory - Used memory for frag",
-                "refId": "C"
-              }
-            ],
-            "title": "Sockstat Memory Size",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 52
-            },
-            "id": 126,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_sockstat_sockets_used{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Sockets_used - Sockets currently in use",
-                "refId": "A",
-                "step": 240
-              }
-            ],
-            "title": "Sockstat Used",
-            "type": "timeseries"
-          }
-        ],
-        "title": "Network Sockstat",
-        "type": "row"
-      },
-      {
-        "collapsed": true,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 58
-        },
-        "id": 274,
-        "panels": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 33
-            },
-            "id": 221,
-            "maxPerRow": 12,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_netstat_IpExt_InOctets{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "InOctets - Received octets",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_netstat_IpExt_OutOctets{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "OutOctets - Sent octets",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "Netstat IP In / Out Octets",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 33
-            },
-            "id": 81,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_netstat_Ip_Forwarding{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Forwarding - IP forwarding",
-                "refId": "A",
-                "step": 240
-              }
-            ],
-            "title": "Netstat IP Forwarding",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 43
-            },
-            "id": 115,
-            "maxPerRow": 12,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_netstat_Icmp_InMsgs{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "InMsgs -  Messages which the entity received. Note that this counter includes all those counted by icmpInErrors",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_netstat_Icmp_OutMsgs{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "OutMsgs - Messages which this entity attempted to send. Note that this counter includes all those counted by icmpOutErrors",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "ICMP In / Out",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 43
-            },
-            "id": 50,
-            "maxPerRow": 12,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_netstat_Icmp_InErrors{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "InErrors - Messages which the entity received but determined as having ICMP-specific errors (bad ICMP checksums, bad length, etc.)",
-                "refId": "A",
-                "step": 240
-              }
-            ],
-            "title": "ICMP Errors",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 53
-            },
-            "id": 55,
-            "maxPerRow": 12,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_netstat_Udp_InDatagrams{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "InDatagrams - Datagrams received",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_netstat_Udp_OutDatagrams{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "OutDatagrams - Datagrams sent",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "UDP In / Out",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 53
-            },
-            "id": 109,
-            "maxPerRow": 12,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_netstat_Udp_InErrors{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "InErrors - UDP Datagrams that could not be delivered to an application",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_netstat_Udp_NoPorts{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "NoPorts - UDP Datagrams received on a port with no listener",
-                "refId": "B",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_netstat_UdpLite_InErrors{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "interval": "",
-                "legendFormat": "InErrors Lite - UDPLite Datagrams that could not be delivered to an application",
-                "refId": "C"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_netstat_Udp_RcvbufErrors{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "RcvbufErrors - UDP buffer errors received",
-                "refId": "D",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_netstat_Udp_SndbufErrors{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "SndbufErrors - UDP buffer errors send",
-                "refId": "E",
-                "step": 240
-              }
-            ],
-            "title": "UDP Errors",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 63
-            },
-            "id": 299,
-            "maxPerRow": 12,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_netstat_Tcp_InSegs{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "instant": false,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "InSegs - Segments received, including those received in error. This count includes segments received on currently established connections",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_netstat_Tcp_OutSegs{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "OutSegs - Segments sent, including those on current connections but excluding those containing only retransmitted octets",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "TCP In / Out",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "description": "",
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 63
-            },
-            "id": 104,
-            "maxPerRow": 12,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_netstat_TcpExt_ListenOverflows{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "hide": false,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "ListenOverflows - Times the listen queue of a socket overflowed",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_netstat_TcpExt_ListenDrops{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "hide": false,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "ListenDrops - SYNs to LISTEN sockets ignored",
-                "refId": "B",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_netstat_TcpExt_TCPSynRetrans{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "TCPSynRetrans - SYN-SYN/ACK retransmits to break down retransmissions in SYN, fast/timeout retransmits",
-                "refId": "C",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_netstat_Tcp_RetransSegs{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "interval": "",
-                "legendFormat": "RetransSegs - Segments retransmitted - that is, the number of TCP segments transmitted containing one or more previously transmitted octets",
-                "refId": "D"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_netstat_Tcp_InErrs{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "interval": "",
-                "legendFormat": "InErrs - Segments received in error (e.g., bad TCP checksums)",
-                "refId": "E"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_netstat_Tcp_OutRsts{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "interval": "",
-                "legendFormat": "OutRsts - Segments sent with RST flag",
-                "refId": "F"
-              }
-            ],
-            "title": "TCP Errors",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 73
-            },
-            "id": 85,
-            "maxPerRow": 12,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_netstat_Tcp_CurrEstab{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "hide": false,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "CurrEstab - TCP connections for which the current state is either ESTABLISHED or CLOSE- WAIT",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_netstat_Tcp_MaxConn{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "hide": false,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "MaxConn - Limit on the total number of TCP connections the entity can support (Dinamic is \"-1\")",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "TCP Connections",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "description": "",
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 73
-            },
-            "id": 91,
-            "maxPerRow": 12,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_netstat_TcpExt_SyncookiesFailed{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "hide": false,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "SyncookiesFailed - Invalid SYN cookies received",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_netstat_TcpExt_SyncookiesRecv{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "hide": false,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "SyncookiesRecv - SYN cookies received",
-                "refId": "B",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_netstat_TcpExt_SyncookiesSent{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "hide": false,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "SyncookiesSent - SYN cookies sent",
-                "refId": "C",
-                "step": 240
-              }
-            ],
-            "title": "TCP SynCookie",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "custom": {},
-                "links": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 83
-            },
-            "id": 82,
-            "maxPerRow": 12,
-            "options": {
-              "alertThreshold": true
-            },
-            "pluginVersion": "7.3.7",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_netstat_Tcp_ActiveOpens{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "ActiveOpens - TCP connections that have made a direct transition to the SYN-SENT state from the CLOSED state",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "rate(node_netstat_Tcp_PassiveOpens{supabase_project_ref=\"$project\"}[$__rate_interval])",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "PassiveOpens - TCP connections that have made a direct transition to the SYN-RCVD state from the LISTEN state",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "TCP Direct Transition",
-            "type": "timeseries"
-          }
-        ],
-        "title": "Network Netstat",
-        "type": "row"
-      },
-      {
-        "collapsed": true,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 59
-        },
-        "id": 279,
-        "panels": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "description": "",
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 0,
-              "y": 54
-            },
-            "id": 40,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_scrape_collector_duration_seconds{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "hide": false,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "{{collector}} - Scrape duration",
-                "refId": "A",
-                "step": 240
-              }
-            ],
-            "title": "Node Exporter Scrape Time",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "description": "",
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 12,
-              "x": 12,
-              "y": 54
-            },
-            "id": 157,
-            "options": {
-              "dataLinks": []
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_scrape_collector_success{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "hide": false,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "{{collector}} - Scrape success",
-                "refId": "A",
-                "step": 240
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${DS_PROMETHEUS}"
-                },
-                "expr": "node_textfile_scrape_error{supabase_project_ref=\"$project\"}",
-                "format": "time_series",
-                "hide": false,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "{{collector}} - Scrape textfile error (1 = true)",
-                "refId": "B",
-                "step": 240
-              }
-            ],
-            "title": "Node Exporter Scrape",
-            "type": "timeseries"
-          }
-        ],
-        "title": "Node Exporter",
-        "type": "row"
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
       }
-    ],
-    "refresh": "",
-    "schemaVersion": 40,
-    "tags": [],
-    "templating": {
-      "list": [
-        {
-          "current": {},
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 261,
+      "panels": [],
+      "title": "Quick CPU / Mem / Disk",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+      },
+      "description": "Busy state of all CPU cores together",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
           },
-          "definition": "label_values(supabase_project_ref)",
-          "includeAll": false,
-          "label": "Project Ref",
-          "name": "project",
-          "options": [],
-          "query": {
-            "query": "label_values(supabase_project_ref)",
-            "refId": "PrometheusVariableQueryEditor-VariableQuery"
-          },
-          "refresh": 1,
-          "regex": "",
-          "type": "query"
-        },
-        {
-          "current": {
-            "text": "[a-z]+|nvme[0-9]+n[0-9]+|mmcblk[0-9]+",
-            "value": "[a-z]+|nvme[0-9]+n[0-9]+|mmcblk[0-9]+"
-          },
-          "hide": 2,
-          "includeAll": false,
-          "name": "diskdevices",
-          "options": [
+          "mappings": [
             {
-              "selected": true,
-              "text": "[a-z]+|nvme[0-9]+n[0-9]+|mmcblk[0-9]+",
-              "value": "[a-z]+|nvme[0-9]+n[0-9]+|mmcblk[0-9]+"
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
             }
           ],
-          "query": "[a-z]+|nvme[0-9]+n[0-9]+|mmcblk[0-9]+",
-          "type": "custom"
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgba(50, 172, 45, 0.97)",
+                "value": 0
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 85
+              },
+              {
+                "color": "rgba(245, 54, 54, 0.9)",
+                "value": 95
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 1
+      },
+      "id": 20,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "12.1.0-88993",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "expr": "clamp_min(100 - (avg(rate(node_cpu_seconds_total{mode=\"idle\", supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) by (instance) * 100), 0)",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A",
+          "step": 240
         }
-      ]
+      ],
+      "title": "CPU Busy",
+      "type": "gauge"
     },
-    "time": {
-      "from": "now-1h",
-      "to": "now"
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+      },
+      "description": "Busy state of all CPU cores together (5 min average)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgba(50, 172, 45, 0.97)",
+                "value": 0
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 85
+              },
+              {
+                "color": "rgba(245, 54, 54, 0.9)",
+                "value": 95
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 3,
+        "y": 1
+      },
+      "id": 155,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "12.1.0-88993",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "expr": "avg(node_load5{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}) /  count(count(node_cpu_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}) by (cpu)) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "refId": "A",
+          "step": 240
+        }
+      ],
+      "title": "Sys Load (5m avg)",
+      "type": "gauge"
     },
-    "timepicker": {},
-    "timezone": "utc",
-    "title": "Supabase Project",
-    "uid": "d402d94e-da48-48e4-ac52-53026b96a001",
-    "version": 1,
-    "weekStart": "mon"
-  }
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+      },
+      "description": "Busy state of all CPU cores together (15 min average)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgba(50, 172, 45, 0.97)",
+                "value": 0
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 85
+              },
+              {
+                "color": "rgba(245, 54, 54, 0.9)",
+                "value": 95
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 6,
+        "y": 1
+      },
+      "id": 19,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "12.1.0-88993",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "expr": "avg(node_load15{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}) /  count(count(node_cpu_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}) by (cpu)) * 100",
+          "hide": false,
+          "intervalFactor": 1,
+          "refId": "A",
+          "step": 240
+        }
+      ],
+      "title": "Sys Load (15m avg)",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+      },
+      "description": "Non available RAM memory",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgba(50, 172, 45, 0.97)",
+                "value": 0
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 80
+              },
+              {
+                "color": "rgba(245, 54, 54, 0.9)",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 9,
+        "y": 1
+      },
+      "id": 16,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "12.1.0-88993",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "expr": "((node_memory_MemTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_MemFree_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}) / (node_memory_MemTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} )) * 100",
+          "format": "time_series",
+          "hide": true,
+          "intervalFactor": 1,
+          "refId": "A",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "expr": "100 - ((node_memory_MemAvailable_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} * 100) / node_memory_MemTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"})",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "refId": "B",
+          "step": 240
+        }
+      ],
+      "title": "RAM Used",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+      },
+      "description": "Used Swap",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgba(50, 172, 45, 0.97)",
+                "value": 0
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 10
+              },
+              {
+                "color": "rgba(245, 54, 54, 0.9)",
+                "value": 25
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 12,
+        "y": 1
+      },
+      "id": 21,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "12.1.0-88993",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "expr": "((node_memory_SwapTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_SwapFree_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}) / (node_memory_SwapTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} )) * 100",
+          "intervalFactor": 1,
+          "refId": "A",
+          "step": 240
+        }
+      ],
+      "title": "SWAP Used",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+      },
+      "description": "Used Root FS",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgba(50, 172, 45, 0.97)",
+                "value": 0
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 80
+              },
+              {
+                "color": "rgba(245, 54, 54, 0.9)",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 15,
+        "y": 1
+      },
+      "id": 154,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "12.1.0-88993",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "expr": "100 - ((node_filesystem_avail_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",mountpoint=\"/\",fstype!=\"rootfs\"} * 100) / node_filesystem_size_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",mountpoint=\"/\",fstype!=\"rootfs\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A",
+          "step": 240
+        }
+      ],
+      "title": "Root FS Used",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+      },
+      "description": "Total number of CPU cores",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 18,
+        "y": 1
+      },
+      "id": 14,
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.1.0-88993",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "expr": "count(count(node_cpu_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}) by (cpu))",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A",
+          "step": 240
+        }
+      ],
+      "title": "CPU Cores",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+      },
+      "description": "System uptime",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 20,
+        "y": 1
+      },
+      "id": 15,
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.1.0-88993",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "node_time_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_boot_time_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A",
+          "step": 240
+        }
+      ],
+      "title": "Uptime",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+      },
+      "description": "Total SWAP",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 22,
+        "y": 1
+      },
+      "id": 18,
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.1.0-88993",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "expr": "node_memory_SwapTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+          "intervalFactor": 1,
+          "refId": "A",
+          "step": 240
+        }
+      ],
+      "title": "SWAP Total",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+      },
+      "description": "Total RootFS",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgba(50, 172, 45, 0.97)",
+                "value": 0
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 70
+              },
+              {
+                "color": "rgba(245, 54, 54, 0.9)",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 18,
+        "y": 3
+      },
+      "id": 23,
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.1.0-88993",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "node_filesystem_size_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",mountpoint=\"/\",fstype!=\"rootfs\"}",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A",
+          "step": 240
+        }
+      ],
+      "title": "RootFS Total",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+      },
+      "description": "Total data disk capacity",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgba(50, 172, 45, 0.97)",
+                "value": 0
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 70
+              },
+              {
+                "color": "rgba(245, 54, 54, 0.9)",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 20,
+        "y": 3
+      },
+      "id": 322,
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.1.0-88993",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "node_filesystem_size_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",mountpoint=\"/data\",fstype!=\"rootfs\"}",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "queryType": "measurements",
+          "refId": "A",
+          "step": 240
+        }
+      ],
+      "title": "Data Disk Total",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+      },
+      "description": "Total RAM",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 22,
+        "y": 3
+      },
+      "id": 75,
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.1.0-88993",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "expr": "node_memory_MemTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+          "intervalFactor": 1,
+          "refId": "A",
+          "step": 240
+        }
+      ],
+      "title": "RAM Total",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 263,
+      "panels": [],
+      "title": "Basic CPU / Mem / Net / Disk",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+      },
+      "description": "Basic CPU info",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "percent"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Busy"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#EAB839",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Busy Iowait"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#890F02",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Busy other"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#1F78C1",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Idle"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#052B51",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Idle - Waiting for something to happen"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#052B51",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "guest"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#9AC48A",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "idle"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#052B51",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "iowait"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#EAB839",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "irq"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#BF1B00",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "nice"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#C15C17",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "softirq"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#E24D42",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "steal"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FCE2DE",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "system"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#508642",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "user"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#5195CE",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Busy Iowait"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#890F02",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Idle"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#7EB26D",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Busy System"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#EAB839",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Busy User"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#0A437C",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Busy Other"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#6D1F62",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 77,
+      "maxPerRow": 6,
+      "options": {
+        "alertThreshold": true,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "width": 250
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0-88993",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode=\"system\",supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "Busy System",
+          "refId": "A",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode='user',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "Busy User",
+          "refId": "B",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode='iowait',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Busy Iowait",
+          "refId": "C",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode=~\".*irq\",supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Busy IRQs",
+          "refId": "D",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "expr": "sum (rate(node_cpu_seconds_total{mode!='idle',mode!='user',mode!='system',mode!='iowait',mode!='irq',mode!='softirq',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Busy Other",
+          "refId": "E",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='idle',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Idle",
+          "refId": "F",
+          "step": 240
+        }
+      ],
+      "title": "CPU Basic",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+      },
+      "description": "Basic memory usage",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Apps"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#629E51",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Buffers"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#614D93",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Cache"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#6D1F62",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Cached"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#511749",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Committed"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#508642",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Free"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#0A437C",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Hardware Corrupted - Amount of RAM that the kernel identified as corrupted / not working"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#CFFAFF",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Inactive"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#584477",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PageTables"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#0A50A1",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Page_Tables"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#0A50A1",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RAM_Free"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#E0F9D7",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SWAP Used"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#BF1B00",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Slab"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#806EB7",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Slab_Cache"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#E0752D",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Swap"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#BF1B00",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Swap Used"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#BF1B00",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Swap_Cache"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#C15C17",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Swap_Free"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#2F575E",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Unused"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#EAB839",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RAM Total"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#E0F9D7",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RAM Cache + Buffer"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#052B51",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RAM Free"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#7EB26D",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Avaliable"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#DEDAF7",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 78,
+      "maxPerRow": 6,
+      "options": {
+        "alertThreshold": true,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "width": 350
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0-88993",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "expr": "node_memory_MemTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "RAM Total",
+          "refId": "A",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "expr": "node_memory_MemTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_MemFree_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - (node_memory_Cached_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} + node_memory_Buffers_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"})",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "RAM Used",
+          "refId": "B",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "expr": "node_memory_Cached_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} + node_memory_Buffers_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "RAM Cache + Buffer",
+          "refId": "C",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "expr": "node_memory_MemFree_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "RAM Free",
+          "refId": "D",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "expr": "(node_memory_SwapTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_SwapFree_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "SWAP Used",
+          "refId": "E",
+          "step": 240
+        }
+      ],
+      "title": "Memory Basic",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+      },
+      "description": "Basic network info per interface",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Recv_bytes_eth2"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#7EB26D",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Recv_bytes_lo"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#0A50A1",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Recv_drop_eth2"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#6ED0E0",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Recv_drop_lo"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#E0F9D7",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Recv_errs_eth2"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#BF1B00",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Recv_errs_lo"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#CCA300",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Trans_bytes_eth2"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#7EB26D",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Trans_bytes_lo"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#0A50A1",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Trans_drop_eth2"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#6ED0E0",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Trans_drop_lo"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#E0F9D7",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Trans_errs_eth2"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#BF1B00",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Trans_errs_lo"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#CCA300",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "recv_bytes_lo"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#0A50A1",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "recv_drop_eth0"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#99440A",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "recv_drop_lo"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#967302",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "recv_errs_eth0"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#BF1B00",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "recv_errs_lo"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#890F02",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "trans_bytes_eth0"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#7EB26D",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "trans_bytes_lo"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#0A50A1",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "trans_drop_eth0"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#99440A",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "trans_drop_lo"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#967302",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "trans_errs_eth0"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#BF1B00",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "trans_errs_lo"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#890F02",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*trans.*/"
+            },
+            "properties": [
+              {
+                "id": "custom.transform",
+                "value": "negative-Y"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 13
+      },
+      "id": 74,
+      "options": {
+        "alertThreshold": true,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0-88993",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "expr": "rate(node_network_receive_bytes_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])*8",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "recv {{device}}",
+          "refId": "A",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "expr": "rate(node_network_transmit_bytes_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])*8",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "trans {{device}} ",
+          "refId": "B",
+          "step": 240
+        }
+      ],
+      "title": "Network Traffic Basic",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+      },
+      "description": "Disk space used of all filesystems mounted",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "EBS Balance"
+            },
+            "properties": [
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 13
+      },
+      "id": 152,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0-88993",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "expr": "100 - ((node_filesystem_avail_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'} * 100) / node_filesystem_size_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Disk mounted at {{mountpoint}}",
+          "refId": "A",
+          "step": 240
+        }
+      ],
+      "title": "Disk Space Used, EBS IO Balance",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 317,
+      "panels": [],
+      "title": "Postgres",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+      },
+      "description": "Disk space used by the database",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMax": 100,
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "decmbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 21
+      },
+      "id": 321,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0-88993",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "pg_database_size_mb{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Database size",
+          "refId": "A",
+          "step": 240
+        }
+      ],
+      "title": "Database size ",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+      },
+      "description": "Active number of client connections",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMax": 20,
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pgbouncer client connections waiting"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 9,
+        "x": 12,
+        "y": 21
+      },
+      "id": 323,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0-88993",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "pg_stat_database_num_backends{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "postgres connections",
+          "refId": "A",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "sum(supavisor_connections_active{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"})",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "supavisor connections",
+          "refId": "B",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "pgbouncer_used_clients{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "pgbouncer connections",
+          "refId": "C",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "sum by (Name) (pgbouncer_pools_client_waiting_connections{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"})",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "pgbouncer client connections waiting",
+          "refId": "D",
+          "step": 240
+        }
+      ],
+      "title": "Client connections",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "Stopped"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "Running"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 21,
+        "y": 21
+      },
+      "id": 319,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.1.0-88993",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "pg_up{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Postgres status",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "Stopped"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "Running"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 21,
+        "y": 24
+      },
+      "id": 341,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.1.0-88993",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "pgbouncer_up{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "pgbouncer status",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMax": 5,
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total time spent"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "s"
+              },
+              {
+                "id": "custom.axisSoftMax"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 7,
+        "x": 0,
+        "y": 27
+      },
+      "id": 330,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0-88993",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "rate(supabase_usage_metrics_user_queries_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "No. of user queries",
+          "refId": "A",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "rate(pg_stat_statements_total_queries{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Total no. of queries",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "rate(pg_stat_statements_total_time_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Total time spent",
+          "refId": "C"
+        }
+      ],
+      "title": "Query stats",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMax": 5,
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Deadlocks detected"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "custom.axisSoftMax",
+                "value": 25
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 7,
+        "x": 7,
+        "y": 27
+      },
+      "id": 342,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0-88993",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "rate(pg_stat_database_xact_commit_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Tx committed",
+          "refId": "A",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "rate(pg_stat_database_xact_rollback_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Tx rolled back",
+          "refId": "B",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "rate(pg_stat_database_deadlocks_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Deadlocks detected",
+          "refId": "C",
+          "step": 240
+        }
+      ],
+      "title": "pg stats",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMax": 5,
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total time spent"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "s"
+              },
+              {
+                "id": "custom.axisSoftMax"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 7,
+        "x": 14,
+        "y": 27
+      },
+      "id": 331,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0-88993",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "rate(pg_stat_database_conflicts_confl_tablespace_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Dropped tablespaces",
+          "refId": "A",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "rate(pg_stat_database_conflicts_confl_lock_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Lock timeouts",
+          "refId": "B",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "rate(pg_stat_database_conflicts_confl_snapshot_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Old Snapshots",
+          "refId": "C",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "rate(pg_stat_database_conflicts_confl_bufferpin_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Pinned buffers",
+          "refId": "D",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "rate(pg_stat_database_conflicts_confl_deadlock_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Deadlocks",
+          "refId": "E",
+          "step": 240
+        }
+      ],
+      "title": "Conflicts - Queries cancelled due to",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "ReadWrite"
+                },
+                "1": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "ReadOnly"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 21,
+        "y": 27
+      },
+      "id": 324,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "limit": 2,
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.1.0-88993",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "pg_settings_default_transaction_read_only{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "DB Mode",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "No"
+                },
+                "1": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "Yes"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 21,
+        "y": 30
+      },
+      "id": 325,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.1.0-88993",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "pg_status_in_recovery{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "In Recovery",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "id": 337,
+      "panels": [],
+      "title": "Postgres: realtime",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+      },
+      "description": "Realtime replication status",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "Inactive"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "Active"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 0,
+        "y": 35
+      },
+      "id": 328,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "replication_realtime_slot_status{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Realtime replication status",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMax": 20,
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 7,
+        "x": 3,
+        "y": 35
+      },
+      "id": 329,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "replication_realtime_lag_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Replication lag ",
+          "refId": "A",
+          "step": 240
+        }
+      ],
+      "title": "Realtime replication lag",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 38
+      },
+      "id": 335,
+      "panels": [],
+      "title": "Postgres: bgwriter",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMax": 5,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/^Time spent/"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "ms"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 39
+      },
+      "id": 332,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "pluginVersion": "8.3.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "rate(pg_stat_bgwriter_checkpoints_timed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Scheduled checkpoints",
+          "refId": "A",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "rate(pg_stat_bgwriter_checkpoints_req_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Requested checkpoints",
+          "refId": "B",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "rate(pg_stat_bgwriter_checkpoint_write_time_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Time spent writing checkpoint files",
+          "refId": "C",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "rate(pg_stat_bgwriter_checkpoint_sync_time_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Time spent synchronizing checkpoint files",
+          "refId": "D",
+          "step": 240
+        }
+      ],
+      "title": "bgwriter stats: checkpoints",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMax": 5,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Allocated"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 39
+      },
+      "id": 333,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "pluginVersion": "8.3.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "rate(pg_stat_bgwriter_buffers_checkpoint_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Written during checkpoints",
+          "refId": "A",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "rate(pg_stat_bgwriter_buffers_clean_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Written by bgwriter",
+          "refId": "B",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "rate(pg_stat_bgwriter_buffers_backend_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Written by a backend",
+          "refId": "C",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "rate(pg_stat_bgwriter_buffers_alloc_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Allocated",
+          "refId": "D",
+          "step": 240
+        }
+      ],
+      "title": "bgwriter stats: buffers",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMax": 5,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Backend fsync calls"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 39
+      },
+      "id": 340,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "pluginVersion": "8.3.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "rate(pg_stat_bgwriter_maxwritten_clean_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "No. of times clean stopped due to writing too many buffers",
+          "refId": "A",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "exemplar": false,
+          "expr": "rate(pg_stat_bgwriter_buffers_backend_fsync_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Fsync calls by backend",
+          "refId": "D",
+          "step": 240
+        }
+      ],
+      "title": "bgwriter: fsync/clean",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 46
+      },
+      "id": 265,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 12,
+            "w": 12,
+            "x": 0,
+            "y": 3
+          },
+          "id": 3,
+          "maxPerRow": 6,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode=\"system\",supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
+              "format": "time_series",
+              "interval": "10s",
+              "intervalFactor": 1,
+              "legendFormat": "System - Processes executing in kernel mode",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='user',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "User - Normal processes executing in user mode",
+              "refId": "B",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='nice',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Nice - Niced processes executing in user mode",
+              "refId": "C",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='idle',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Idle - Waiting for something to happen",
+              "refId": "D",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='iowait',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Iowait - Waiting for I/O to complete",
+              "refId": "E",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='irq',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Irq - Servicing interrupts",
+              "refId": "F",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='softirq',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Softirq - Servicing softirqs",
+              "refId": "G",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='steal',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Steal - Time spent in other operating systems when running in a virtualized environment",
+              "refId": "H",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='guest',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Guest - Time spent running a virtual CPU for a guest operating system",
+              "refId": "I",
+              "step": 240
+            }
+          ],
+          "title": "CPU",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 12,
+            "w": 12,
+            "x": 12,
+            "y": 3
+          },
+          "id": 24,
+          "maxPerRow": 6,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_MemTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_MemFree_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_Buffers_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_Cached_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_Slab_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_PageTables_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_SwapCached_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "Apps - Memory used by user-space applications",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_PageTables_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "PageTables - Memory used to map between virtual and physical memory addresses",
+              "refId": "B",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_SwapCached_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "SwapCache - Memory that keeps track of pages that have been fetched from swap but not yet been modified",
+              "refId": "C",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_Slab_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "Slab - Memory used by the kernel to cache data structures for its own use (caches like inode, dentry, etc)",
+              "refId": "D",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_Cached_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "Cache - Parked file data (file content) cache",
+              "refId": "E",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_Buffers_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "Buffers - Block device (e.g. harddisk) cache",
+              "refId": "F",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_MemFree_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "Unused - Free memory unassigned",
+              "refId": "G",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "(node_memory_SwapTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_SwapFree_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"})",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "Swap - Swap space used",
+              "refId": "H",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_HardwareCorrupted_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "Hardware Corrupted - Amount of RAM that the kernel identified as corrupted / not working",
+              "refId": "I",
+              "step": 240
+            }
+          ],
+          "title": "Memory Stack",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 12,
+            "w": 12,
+            "x": 0,
+            "y": 15
+          },
+          "id": 84,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_network_receive_bytes_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])*8",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{device}} - Receive",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_network_transmit_bytes_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])*8",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{device}} - Transmit",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "Network Traffic",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 12,
+            "w": 12,
+            "x": 12,
+            "y": 15
+          },
+          "id": 156,
+          "maxPerRow": 6,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_filesystem_size_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'} - node_filesystem_avail_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{mountpoint}}",
+              "refId": "A",
+              "step": 240
+            }
+          ],
+          "title": "Disk Space Used",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 12,
+            "w": 12,
+            "x": 0,
+            "y": 27
+          },
+          "id": 229,
+          "maxPerRow": 6,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_disk_reads_completed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device=~\"$diskdevices\"}[$__rate_interval])",
+              "intervalFactor": 1,
+              "legendFormat": "{{device}} - Reads completed",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_disk_writes_completed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device=~\"$diskdevices\"}[$__rate_interval])",
+              "intervalFactor": 1,
+              "legendFormat": "{{device}} - Writes completed",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "Disk IOps",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 12,
+            "w": 12,
+            "x": 12,
+            "y": 27
+          },
+          "id": 42,
+          "maxPerRow": 6,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_disk_read_bytes_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device=~\"$diskdevices\"}[$__rate_interval])",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "{{device}} - Successfully read bytes",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_disk_written_bytes_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device=~\"$diskdevices\"}[$__rate_interval])",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "{{device}} - Successfully written bytes",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "I/O Usage Read / Write",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 12,
+            "w": 12,
+            "x": 0,
+            "y": 39
+          },
+          "id": 127,
+          "maxPerRow": 6,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_disk_io_time_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device=~\"$diskdevices\"} [$__rate_interval])",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{device}}",
+              "refId": "A",
+              "step": 240
+            }
+          ],
+          "title": "I/O Utilization",
+          "type": "timeseries"
+        }
+      ],
+      "title": "CPU / Memory / Net / Disk",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 47
+      },
+      "id": 266,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 70
+          },
+          "id": 136,
+          "maxPerRow": 2,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_Inactive_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Inactive - Memory which has been less recently used.  It is more eligible to be reclaimed for other purposes",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_Active_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Active - Memory that has been used more recently and usually not reclaimed unless absolutely necessary",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "Memory Active / Inactive",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 70
+          },
+          "id": 135,
+          "maxPerRow": 6,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_Committed_AS_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Committed_AS - Amount of memory presently allocated on the system",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_CommitLimit_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "CommitLimit - Amount of  memory currently available to be allocated on the system",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "Memory Commited",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 80
+          },
+          "id": 191,
+          "maxPerRow": 6,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_Inactive_file_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "Inactive_file - File-backed memory on inactive LRU list",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_Inactive_anon_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "Inactive_anon - Anonymous and swap cache on inactive LRU list, including tmpfs (shmem)",
+              "refId": "B",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_Active_file_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "Active_file - File-backed memory on active LRU list",
+              "refId": "C",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_Active_anon_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "Active_anon - Anonymous and swap cache on active least-recently-used (LRU) list, including tmpfs",
+              "refId": "D",
+              "step": 240
+            }
+          ],
+          "title": "Memory Active / Inactive Detail",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 80
+          },
+          "id": 130,
+          "maxPerRow": 2,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_Writeback_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Writeback - Memory which is actively being written back to disk",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_WritebackTmp_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "WritebackTmp - Memory used by FUSE for temporary writeback buffers",
+              "refId": "B",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_Dirty_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Dirty - Memory which is waiting to get written back to the disk",
+              "refId": "C",
+              "step": 240
+            }
+          ],
+          "title": "Memory Writeback and Dirty",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 90
+          },
+          "id": 138,
+          "maxPerRow": 6,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_Mapped_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Mapped - Used memory in mapped pages files which have been mmaped, such as libraries",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_Shmem_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Shmem - Used shared memory (shared between several processes, thus including RAM disks)",
+              "refId": "B",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_ShmemHugePages_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "ShmemHugePages - Memory used by shared memory (shmem) and tmpfs allocated  with huge pages",
+              "refId": "C",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_ShmemPmdMapped_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "ShmemPmdMapped - Ammount of shared (shmem/tmpfs) memory backed by huge pages",
+              "refId": "D",
+              "step": 240
+            }
+          ],
+          "title": "Memory Shared and Mapped",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 90
+          },
+          "id": 131,
+          "maxPerRow": 2,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_SUnreclaim_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "SUnreclaim - Part of Slab, that cannot be reclaimed on memory pressure",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_SReclaimable_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "SReclaimable - Part of Slab, that might be reclaimed, such as caches",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "Memory Slab",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 100
+          },
+          "id": 70,
+          "maxPerRow": 6,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_VmallocChunk_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "VmallocChunk - Largest contigious block of vmalloc area which is free",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_VmallocTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "VmallocTotal - Total size of vmalloc memory area",
+              "refId": "B",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_VmallocUsed_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "VmallocUsed - Amount of vmalloc area which is used",
+              "refId": "C",
+              "step": 240
+            }
+          ],
+          "title": "Memory Vmalloc",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 100
+          },
+          "id": 159,
+          "maxPerRow": 6,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_Bounce_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Bounce - Memory used for block device bounce buffers",
+              "refId": "A",
+              "step": 240
+            }
+          ],
+          "title": "Memory Bounce",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 110
+          },
+          "id": 129,
+          "maxPerRow": 6,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_AnonHugePages_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "AnonHugePages - Memory in anonymous huge pages",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_AnonPages_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "AnonPages - Memory in user pages not backed by files",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "Memory Anonymous",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 110
+          },
+          "id": 160,
+          "maxPerRow": 2,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_KernelStack_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "KernelStack - Kernel memory stack. This is not reclaimable",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_Percpu_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "PerCPU - Per CPU memory allocated dynamically by loadable modules",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "Memory Kernel / CPU",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 120
+          },
+          "id": 140,
+          "maxPerRow": 6,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_HugePages_Free{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "HugePages_Free - Huge pages in the pool that are not yet allocated",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_HugePages_Rsvd{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "HugePages_Rsvd - Huge pages for which a commitment to allocate from the pool has been made, but no allocation has yet been made",
+              "refId": "B",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_HugePages_Surp{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "HugePages_Surp - Huge pages in the pool above the value in /proc/sys/vm/nr_hugepages",
+              "refId": "C",
+              "step": 240
+            }
+          ],
+          "title": "Memory HugePages Counter",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 120
+          },
+          "id": 71,
+          "maxPerRow": 2,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_HugePages_Total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "HugePages - Total size of the pool of huge pages",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_Hugepagesize_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Hugepagesize - Huge Page size",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "Memory HugePages Size",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 130
+          },
+          "id": 128,
+          "maxPerRow": 6,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_DirectMap1G_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "DirectMap1G - Amount of pages mapped as this size",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_DirectMap2M_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "DirectMap2M - Amount of pages mapped as this size",
+              "refId": "B",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_DirectMap4k_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "DirectMap4K - Amount of pages mapped as this size",
+              "refId": "C",
+              "step": 240
+            }
+          ],
+          "title": "Memory DirectMap",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 130
+          },
+          "id": 137,
+          "maxPerRow": 6,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_Unevictable_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Unevictable - Amount of unevictable memory that can't be swapped out for a variety of reasons",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_Mlocked_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "MLocked - Size of pages locked to memory using the mlock() system call",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "Memory Unevictable and MLocked",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 140
+          },
+          "id": 132,
+          "maxPerRow": 6,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_memory_NFS_Unstable_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "NFS Unstable - Memory in NFS pages sent to the server, but not yet commited to the storage",
+              "refId": "A",
+              "step": 240
+            }
+          ],
+          "title": "Memory NFS",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Memory Meminfo",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 48
+      },
+      "id": 267,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 23
+          },
+          "id": 176,
+          "maxPerRow": 6,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_vmstat_pgpgin{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Pagesin - Page in operations",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_vmstat_pgpgout{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Pagesout - Page out operations",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "Memory Pages In / Out",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 23
+          },
+          "id": 22,
+          "maxPerRow": 6,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_vmstat_pswpin{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Pswpin - Pages swapped in",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_vmstat_pswpout{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Pswpout - Pages swapped out",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "Memory Pages Swap In / Out",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 33
+          },
+          "id": 175,
+          "maxPerRow": 6,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_vmstat_pgfault{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Pgfault - Page major and minor fault operations",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_vmstat_pgmajfault{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Pgmajfault - Major page fault operations",
+              "refId": "B",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_vmstat_pgfault{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])  - rate(node_vmstat_pgmajfault{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Pgminfault - Minor page fault operations",
+              "refId": "C",
+              "step": 240
+            }
+          ],
+          "title": "Memory Page Faults",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 33
+          },
+          "id": 307,
+          "maxPerRow": 6,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_vmstat_oom_kill{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "oom killer invocations ",
+              "refId": "A",
+              "step": 240
+            }
+          ],
+          "title": "OOM Killer",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Memory Vmstat",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 49
+      },
+      "id": 293,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 24
+          },
+          "id": 260,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_timex_estimated_error_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Estimated error in seconds",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_timex_offset_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Time offset in between local system and reference clock",
+              "refId": "B",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_timex_maxerror_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Maximum error in seconds",
+              "refId": "C",
+              "step": 240
+            }
+          ],
+          "title": "Time Syncronized Drift",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 24
+          },
+          "id": 291,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_timex_loop_time_constant{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Phase-locked loop time adjust",
+              "refId": "A",
+              "step": 240
+            }
+          ],
+          "title": "Time PLL Adjust",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 34
+          },
+          "id": 168,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_timex_sync_status{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Is clock synchronized to a reliable server (1 = yes, 0 = no)",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_timex_frequency_adjustment_ratio{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Local clock frequency adjustment",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "Time Syncronized Status",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 34
+          },
+          "id": 294,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_timex_tick_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Seconds between clock ticks",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_timex_tai_offset_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "International Atomic Time (TAI) offset",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "Time Misc",
+          "type": "timeseries"
+        }
+      ],
+      "title": "System Timesync",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 50
+      },
+      "id": 312,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 7
+          },
+          "id": 62,
+          "maxPerRow": 6,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_procs_blocked{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Processes blocked waiting for I/O to complete",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_procs_running{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Processes in runnable state",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "Processes Status",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 7
+          },
+          "id": 315,
+          "maxPerRow": 6,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_processes_state{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{ state }}",
+              "refId": "A",
+              "step": 240
+            }
+          ],
+          "title": "Processes State",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 17
+          },
+          "id": 148,
+          "maxPerRow": 6,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_forks_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "Processes forks second",
+              "refId": "A",
+              "step": 240
+            }
+          ],
+          "title": "Processes  Forks",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 17
+          },
+          "id": 149,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(process_virtual_memory_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Processes virtual memory size in bytes",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "process_resident_memory_max_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Maximum amount of virtual memory available in bytes",
+              "refId": "B",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(process_virtual_memory_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Processes virtual memory size in bytes",
+              "refId": "C",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(process_virtual_memory_max_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Maximum amount of virtual memory available in bytes",
+              "refId": "D",
+              "step": 240
+            }
+          ],
+          "title": "Processes Memory",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 27
+          },
+          "id": 313,
+          "maxPerRow": 6,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_processes_pids{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Number of PIDs",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_processes_max_processes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "PIDs limit",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "PIDs Number and Limit",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 27
+          },
+          "id": 305,
+          "maxPerRow": 6,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_schedstat_running_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "CPU {{ cpu }} - seconds spent running a process",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_schedstat_waiting_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "CPU {{ cpu }} - seconds spent by processing waiting for this CPU",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "Process schedule stats Running / Waiting",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 37
+          },
+          "id": 314,
+          "maxPerRow": 6,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_processes_threads{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Allocated threads",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_processes_max_threads{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Threads limit",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "Threads Number and Limit",
+          "type": "timeseries"
+        }
+      ],
+      "title": "System Processes",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 51
+      },
+      "id": 269,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 8
+          },
+          "id": 8,
+          "maxPerRow": 6,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_context_switches_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Context switches",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_intr_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "Interrupts",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "Context Switches / Interrupts",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 8
+          },
+          "id": 7,
+          "maxPerRow": 6,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_load1{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Load 1m",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_load5{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Load 5m",
+              "refId": "B",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_load15{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Load 15m",
+              "refId": "C",
+              "step": 240
+            }
+          ],
+          "title": "System Load",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 18
+          },
+          "id": 259,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_interrupts_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{ type }} - {{ info }}",
+              "refId": "A",
+              "step": 240
+            }
+          ],
+          "title": "Interrupts Detail",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 18
+          },
+          "id": 306,
+          "maxPerRow": 6,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_schedstat_timeslices_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "CPU {{ cpu }}",
+              "refId": "A",
+              "step": 240
+            }
+          ],
+          "title": "Schedule timeslices executed by each cpu",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 28
+          },
+          "id": 151,
+          "maxPerRow": 6,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_entropy_available_bits{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Entropy available to random number generators",
+              "refId": "A",
+              "step": 240
+            }
+          ],
+          "title": "Entropy",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 28
+          },
+          "id": 308,
+          "maxPerRow": 6,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(process_cpu_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Time spent",
+              "refId": "A",
+              "step": 240
+            }
+          ],
+          "title": "CPU time spent in user and system contexts",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 38
+          },
+          "id": 64,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "process_max_fds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Maximum open file descriptors",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "process_open_fds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Open file descriptors",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "File Descriptors",
+          "type": "timeseries"
+        }
+      ],
+      "title": "System Misc",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 52
+      },
+      "id": 304,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 26
+          },
+          "id": 158,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_hwmon_temp_celsius{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{ chip }} {{ sensor }} temp",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_hwmon_temp_crit_alarm_celsius{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "hide": true,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{ chip }} {{ sensor }} Critical Alarm",
+              "refId": "B",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_hwmon_temp_crit_celsius{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{ chip }} {{ sensor }} Critical",
+              "refId": "C",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_hwmon_temp_crit_hyst_celsius{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "hide": true,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{ chip }} {{ sensor }} Critical Historical",
+              "refId": "D",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_hwmon_temp_max_celsius{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "hide": true,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{ chip }} {{ sensor }} Max",
+              "refId": "E",
+              "step": 240
+            }
+          ],
+          "title": "Hardware temperature monitor",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 26
+          },
+          "id": 300,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_cooling_device_cur_state{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Current {{ name }} in {{ type }}",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_cooling_device_max_state{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Max {{ name }} in {{ type }}",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "Throttle cooling device",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 36
+          },
+          "id": 302,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_power_supply_online{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{ power_supply }} online",
+              "refId": "A",
+              "step": 240
+            }
+          ],
+          "title": "Power supply",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Hardware Misc",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 53
+      },
+      "id": 296,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 10
+          },
+          "id": 297,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_systemd_socket_accepted_connections_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{ name }} Connections",
+              "refId": "A",
+              "step": 240
+            }
+          ],
+          "title": "Systemd Sockets",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 10
+          },
+          "id": 298,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_systemd_units{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",state=\"activating\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Activating",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_systemd_units{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",state=\"active\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Active",
+              "refId": "B",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_systemd_units{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",state=\"deactivating\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Deactivating",
+              "refId": "C",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_systemd_units{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",state=\"failed\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Failed",
+              "refId": "D",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_systemd_units{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",state=\"inactive\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Inactive",
+              "refId": "E",
+              "step": 240
+            }
+          ],
+          "title": "Systemd Units State",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Systemd",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 54
+      },
+      "id": 270,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "description": "The number (after merges) of I/O requests completed per second for the device",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 11
+          },
+          "id": 9,
+          "maxPerRow": 6,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_disk_reads_completed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "intervalFactor": 1,
+              "legendFormat": "{{device}} - Reads completed",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_disk_writes_completed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "intervalFactor": 1,
+              "legendFormat": "{{device}} - Writes completed",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "Disk IOps Completed",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "description": "The number of bytes read from or written to the device per second",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 11
+          },
+          "id": 33,
+          "maxPerRow": 6,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_disk_read_bytes_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{device}} - Read bytes",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_disk_written_bytes_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{device}} - Written bytes",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "Disk R/W Data",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "description": "The average time for requests issued to the device to be served. This includes the time spent by the requests in queue and the time spent servicing them.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 21
+          },
+          "id": 37,
+          "maxPerRow": 6,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_disk_read_time_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval]) / rate(node_disk_reads_completed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 4,
+              "legendFormat": "{{device}} - Read wait time avg",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_disk_write_time_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval]) / rate(node_disk_writes_completed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{device}} - Write wait time avg",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "Disk Average Wait Time",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "description": "The average queue length of the requests that were issued to the device",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 21
+          },
+          "id": 35,
+          "maxPerRow": 6,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_disk_io_time_weighted_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{device}}",
+              "refId": "A",
+              "step": 240
+            }
+          ],
+          "title": "Average Queue Size",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "description": "The number of read and write requests merged per second that were queued to the device",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 31
+          },
+          "id": 133,
+          "maxPerRow": 6,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_disk_reads_merged_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "intervalFactor": 1,
+              "legendFormat": "{{device}} - Read merged",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_disk_writes_merged_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "intervalFactor": 1,
+              "legendFormat": "{{device}} - Write merged",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "Disk R/W Merged",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "description": "Percentage of elapsed time during which I/O requests were issued to the device (bandwidth utilization for the device). Device saturation occurs when this value is close to 100% for devices serving requests serially.  But for devices  serving requests in parallel, such as RAID arrays and modern SSDs, this number does not reflect their performance limits.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 31
+          },
+          "id": 36,
+          "maxPerRow": 6,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_disk_io_time_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{device}} - IO",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_disk_discard_time_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{device}} - discard",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "Time Spent Doing I/Os",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "description": "The number of outstanding requests at the instant the sample was taken. Incremented as requests are given to appropriate struct request_queue and decremented as they finish.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 41
+          },
+          "id": 34,
+          "maxPerRow": 6,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_disk_io_now{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"})",
+              "interval": "",
+              "intervalFactor": 4,
+              "legendFormat": "{{device}} - IO now",
+              "refId": "A",
+              "step": 240
+            }
+          ],
+          "title": "Instantaneous Queue Size",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 41
+          },
+          "id": 301,
+          "maxPerRow": 6,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_disk_discards_completed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{device}} - Discards completed",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_disk_discards_merged_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{device}} - Discards merged",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "Disk IOps Discards completed / merged",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Storage Disk",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 55
+      },
+      "id": 271,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 12
+          },
+          "id": 43,
+          "maxPerRow": 6,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_filesystem_avail_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'}",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "{{mountpoint}} - Available",
+              "metric": "",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_filesystem_free_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'}",
+              "format": "time_series",
+              "hide": true,
+              "intervalFactor": 1,
+              "legendFormat": "{{mountpoint}} - Free",
+              "refId": "B",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_filesystem_size_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'}",
+              "format": "time_series",
+              "hide": true,
+              "intervalFactor": 1,
+              "legendFormat": "{{mountpoint}} - Size",
+              "refId": "C",
+              "step": 240
+            }
+          ],
+          "title": "Filesystem space available",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 12
+          },
+          "id": 41,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_filesystem_files_free{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'}",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "{{mountpoint}} - Free file nodes",
+              "refId": "A",
+              "step": 240
+            }
+          ],
+          "title": "File Nodes Free",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 22
+          },
+          "id": 28,
+          "maxPerRow": 6,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_filefd_maximum{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Max open files",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_filefd_allocated{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Open files",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "File Descriptor",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 22
+          },
+          "id": 219,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_filesystem_files{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'}",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "{{mountpoint}} - File nodes total",
+              "refId": "A",
+              "step": 240
+            }
+          ],
+          "title": "File Nodes Size",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 32
+          },
+          "id": 44,
+          "maxPerRow": 6,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_filesystem_readonly{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{mountpoint}} - ReadOnly",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_filesystem_device_error{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs',fstype!~'tmpfs'}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{mountpoint}} - Device error",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "Filesystem in ReadOnly / Error",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Storage Filesystem",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 56
+      },
+      "id": 272,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 30
+          },
+          "id": 60,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_network_receive_packets_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{device}} - Receive",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_network_transmit_packets_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{device}} - Transmit",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "Network Traffic by Packets",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 30
+          },
+          "id": 142,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_network_receive_errs_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{device}} - Receive errors",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_network_transmit_errs_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{device}} - Rransmit errors",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "Network Traffic Errors",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 40
+          },
+          "id": 143,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_network_receive_drop_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{device}} - Receive drop",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_network_transmit_drop_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{device}} - Transmit drop",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "Network Traffic Drop",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 40
+          },
+          "id": 141,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_network_receive_compressed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{device}} - Receive compressed",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_network_transmit_compressed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{device}} - Transmit compressed",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "Network Traffic Compressed",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 50
+          },
+          "id": 146,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_network_receive_multicast_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{device}} - Receive multicast",
+              "refId": "A",
+              "step": 240
+            }
+          ],
+          "title": "Network Traffic Multicast",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 50
+          },
+          "id": 144,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_network_receive_fifo_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{device}} - Receive fifo",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_network_transmit_fifo_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{device}} - Transmit fifo",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "Network Traffic Fifo",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 60
+          },
+          "id": 145,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_network_receive_frame_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "{{device}} - Receive frame",
+              "refId": "A",
+              "step": 240
+            }
+          ],
+          "title": "Network Traffic Frame",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 60
+          },
+          "id": 231,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_network_transmit_carrier_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{device}} - Statistic transmit_carrier",
+              "refId": "A",
+              "step": 240
+            }
+          ],
+          "title": "Network Traffic Carrier",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 70
+          },
+          "id": 232,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_network_transmit_colls_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{device}} - Transmit colls",
+              "refId": "A",
+              "step": 240
+            }
+          ],
+          "title": "Network Traffic Colls",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 70
+          },
+          "id": 61,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_nf_conntrack_entries{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "NF conntrack entries",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_nf_conntrack_entries_limit{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "NF conntrack limit",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "NF Contrack",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 80
+          },
+          "id": 230,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_arp_entries{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{ device }} - ARP entries",
+              "refId": "A",
+              "step": 240
+            }
+          ],
+          "title": "ARP Entries",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 80
+          },
+          "id": 288,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_network_mtu_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{ device }} - Bytes",
+              "refId": "A",
+              "step": 240
+            }
+          ],
+          "title": "MTU",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 90
+          },
+          "id": 280,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_network_speed_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{ device }} - Speed",
+              "refId": "A",
+              "step": 240
+            }
+          ],
+          "title": "Speed",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 90
+          },
+          "id": 289,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_network_transmit_queue_length{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{ device }} -   Interface transmit queue length",
+              "refId": "A",
+              "step": 240
+            }
+          ],
+          "title": "Queue Length",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 100
+          },
+          "id": 290,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_softnet_processed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "CPU {{cpu}} - Processed",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_softnet_dropped_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "CPU {{cpu}} - Dropped",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "Softnet Packets",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 100
+          },
+          "id": 310,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_softnet_times_squeezed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "CPU {{cpu}} - Squeezed",
+              "refId": "A",
+              "step": 240
+            }
+          ],
+          "title": "Softnet Out of Quota",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 110
+          },
+          "id": 309,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_network_up{operstate=\"up\",supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{interface}} - Operational state UP",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_network_carrier{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "instant": false,
+              "legendFormat": "{{device}} - Physical link state",
+              "refId": "B"
+            }
+          ],
+          "title": "Network Operational Status",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Network Traffic",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 57
+      },
+      "id": 273,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 32
+          },
+          "id": 63,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_sockstat_TCP_alloc{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "TCP_alloc - Allocated sockets",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_sockstat_TCP_inuse{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "TCP_inuse - Tcp sockets currently in use",
+              "refId": "B",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_sockstat_TCP_mem{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "hide": true,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "TCP_mem - Used memory for tcp",
+              "refId": "C",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_sockstat_TCP_orphan{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "TCP_orphan - Orphan sockets",
+              "refId": "D",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_sockstat_TCP_tw{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "TCP_tw - Sockets wating close",
+              "refId": "E",
+              "step": 240
+            }
+          ],
+          "title": "Sockstat TCP",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 32
+          },
+          "id": 124,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_sockstat_UDPLITE_inuse{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "UDPLITE_inuse - Udplite sockets currently in use",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_sockstat_UDP_inuse{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "UDP_inuse - Udp sockets currently in use",
+              "refId": "B",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_sockstat_UDP_mem{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "UDP_mem - Used memory for udp",
+              "refId": "C",
+              "step": 240
+            }
+          ],
+          "title": "Sockstat UDP",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 42
+          },
+          "id": 125,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_sockstat_FRAG_inuse{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "FRAG_inuse - Frag sockets currently in use",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_sockstat_RAW_inuse{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "RAW_inuse - Raw sockets currently in use",
+              "refId": "C",
+              "step": 240
+            }
+          ],
+          "title": "Sockstat FRAG / RAW",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 42
+          },
+          "id": 220,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_sockstat_TCP_mem_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "mem_bytes - TCP sockets in that state",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_sockstat_UDP_mem_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "mem_bytes - UDP sockets in that state",
+              "refId": "B",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_sockstat_FRAG_memory{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "FRAG_memory - Used memory for frag",
+              "refId": "C"
+            }
+          ],
+          "title": "Sockstat Memory Size",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 52
+          },
+          "id": 126,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_sockstat_sockets_used{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Sockets_used - Sockets currently in use",
+              "refId": "A",
+              "step": 240
+            }
+          ],
+          "title": "Sockstat Used",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Network Sockstat",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 58
+      },
+      "id": 274,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 33
+          },
+          "id": 221,
+          "maxPerRow": 12,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_netstat_IpExt_InOctets{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "InOctets - Received octets",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_netstat_IpExt_OutOctets{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "OutOctets - Sent octets",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "Netstat IP In / Out Octets",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 33
+          },
+          "id": 81,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_netstat_Ip_Forwarding{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Forwarding - IP forwarding",
+              "refId": "A",
+              "step": 240
+            }
+          ],
+          "title": "Netstat IP Forwarding",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 43
+          },
+          "id": 115,
+          "maxPerRow": 12,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_netstat_Icmp_InMsgs{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "InMsgs -  Messages which the entity received. Note that this counter includes all those counted by icmpInErrors",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_netstat_Icmp_OutMsgs{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "OutMsgs - Messages which this entity attempted to send. Note that this counter includes all those counted by icmpOutErrors",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "ICMP In / Out",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 43
+          },
+          "id": 50,
+          "maxPerRow": 12,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_netstat_Icmp_InErrors{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "InErrors - Messages which the entity received but determined as having ICMP-specific errors (bad ICMP checksums, bad length, etc.)",
+              "refId": "A",
+              "step": 240
+            }
+          ],
+          "title": "ICMP Errors",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 53
+          },
+          "id": 55,
+          "maxPerRow": 12,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_netstat_Udp_InDatagrams{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "InDatagrams - Datagrams received",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_netstat_Udp_OutDatagrams{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "OutDatagrams - Datagrams sent",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "UDP In / Out",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 53
+          },
+          "id": 109,
+          "maxPerRow": 12,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_netstat_Udp_InErrors{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "InErrors - UDP Datagrams that could not be delivered to an application",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_netstat_Udp_NoPorts{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "NoPorts - UDP Datagrams received on a port with no listener",
+              "refId": "B",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_netstat_UdpLite_InErrors{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "interval": "",
+              "legendFormat": "InErrors Lite - UDPLite Datagrams that could not be delivered to an application",
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_netstat_Udp_RcvbufErrors{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "RcvbufErrors - UDP buffer errors received",
+              "refId": "D",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_netstat_Udp_SndbufErrors{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "SndbufErrors - UDP buffer errors send",
+              "refId": "E",
+              "step": 240
+            }
+          ],
+          "title": "UDP Errors",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 63
+          },
+          "id": 299,
+          "maxPerRow": 12,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_netstat_Tcp_InSegs{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "InSegs - Segments received, including those received in error. This count includes segments received on currently established connections",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_netstat_Tcp_OutSegs{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "OutSegs - Segments sent, including those on current connections but excluding those containing only retransmitted octets",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "TCP In / Out",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 63
+          },
+          "id": 104,
+          "maxPerRow": 12,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_netstat_TcpExt_ListenOverflows{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "ListenOverflows - Times the listen queue of a socket overflowed",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_netstat_TcpExt_ListenDrops{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "ListenDrops - SYNs to LISTEN sockets ignored",
+              "refId": "B",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_netstat_TcpExt_TCPSynRetrans{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "TCPSynRetrans - SYN-SYN/ACK retransmits to break down retransmissions in SYN, fast/timeout retransmits",
+              "refId": "C",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_netstat_Tcp_RetransSegs{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "interval": "",
+              "legendFormat": "RetransSegs - Segments retransmitted - that is, the number of TCP segments transmitted containing one or more previously transmitted octets",
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_netstat_Tcp_InErrs{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "interval": "",
+              "legendFormat": "InErrs - Segments received in error (e.g., bad TCP checksums)",
+              "refId": "E"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_netstat_Tcp_OutRsts{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "interval": "",
+              "legendFormat": "OutRsts - Segments sent with RST flag",
+              "refId": "F"
+            }
+          ],
+          "title": "TCP Errors",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 73
+          },
+          "id": 85,
+          "maxPerRow": 12,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_netstat_Tcp_CurrEstab{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "CurrEstab - TCP connections for which the current state is either ESTABLISHED or CLOSE- WAIT",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_netstat_Tcp_MaxConn{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "MaxConn - Limit on the total number of TCP connections the entity can support (Dinamic is \"-1\")",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "TCP Connections",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 73
+          },
+          "id": 91,
+          "maxPerRow": 12,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_netstat_TcpExt_SyncookiesFailed{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "SyncookiesFailed - Invalid SYN cookies received",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_netstat_TcpExt_SyncookiesRecv{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "SyncookiesRecv - SYN cookies received",
+              "refId": "B",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_netstat_TcpExt_SyncookiesSent{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "SyncookiesSent - SYN cookies sent",
+              "refId": "C",
+              "step": 240
+            }
+          ],
+          "title": "TCP SynCookie",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 83
+          },
+          "id": 82,
+          "maxPerRow": 12,
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.3.7",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_netstat_Tcp_ActiveOpens{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "ActiveOpens - TCP connections that have made a direct transition to the SYN-SENT state from the CLOSED state",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "rate(node_netstat_Tcp_PassiveOpens{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "PassiveOpens - TCP connections that have made a direct transition to the SYN-RCVD state from the LISTEN state",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "TCP Direct Transition",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Network Netstat",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 59
+      },
+      "id": 279,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 54
+          },
+          "id": 40,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_scrape_collector_duration_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{collector}} - Scrape duration",
+              "refId": "A",
+              "step": 240
+            }
+          ],
+          "title": "Node Exporter Scrape Time",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 54
+          },
+          "id": 157,
+          "options": {
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_scrape_collector_success{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{collector}} - Scrape success",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+              },
+              "expr": "node_textfile_scrape_error{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{collector}} - Scrape textfile error (1 = true)",
+              "refId": "B",
+              "step": 240
+            }
+          ],
+          "title": "Node Exporter Scrape",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Node Exporter",
+      "type": "row"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 41,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+        },
+        "definition": "label_values(supabase_project_ref)",
+        "includeAll": false,
+        "label": "Project Ref",
+        "name": "project",
+        "options": [],
+        "query": {
+          "query": "label_values(supabase_project_ref)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "[a-z]+|nvme[0-9]+n[0-9]+|mmcblk[0-9]+",
+          "value": "[a-z]+|nvme[0-9]+n[0-9]+|mmcblk[0-9]+"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "name": "diskdevices",
+        "options": [
+          {
+            "selected": true,
+            "text": "[a-z]+|nvme[0-9]+n[0-9]+|mmcblk[0-9]+",
+            "value": "[a-z]+|nvme[0-9]+n[0-9]+|mmcblk[0-9]+"
+          }
+        ],
+        "query": "[a-z]+|nvme[0-9]+n[0-9]+|mmcblk[0-9]+",
+        "type": "custom"
+      },
+      {
+        "allowCustomValue": false,
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+        },
+        "definition": "label_values(supabase_identifier)",
+        "includeAll": false,
+        "label": "Supabase Identifier",
+        "name": "supabase_identifier",
+        "options": [],
+        "query": {
+          "query": "label_values(supabase_identifier)",
+          "refId": "Prometheus-supabase_identifier-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Supabase Project",
+  "uid": "d402d94e-da48-48e4-ac52-53026b96a004",
+  "version": 4,
+  "weekStart": ""
+}

--- a/dashboard.json
+++ b/dashboard.json
@@ -1,8 +1,8 @@
 {
   "__inputs": [
     {
-      "name": "DS_GRAFANACLOUD-ENCIMA-PROM",
-      "label": "grafanacloud-encima-prom",
+      "name": "DS_PROMETHEUS",
+      "label": "prometheus",
       "description": "",
       "type": "datasource",
       "pluginId": "prometheus",
@@ -80,7 +80,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Busy state of all CPU cores together",
       "fieldConfig": {
@@ -134,9 +134,7 @@
         "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -149,7 +147,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "clamp_min(100 - (avg(rate(node_cpu_seconds_total{mode=\"idle\", supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) by (instance) * 100), 0)",
           "hide": false,
@@ -165,7 +163,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Busy state of all CPU cores together (5 min average)",
       "fieldConfig": {
@@ -219,9 +217,7 @@
         "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -234,7 +230,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "avg(node_load5{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}) /  count(count(node_cpu_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}) by (cpu)) * 100",
           "format": "time_series",
@@ -250,7 +246,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Busy state of all CPU cores together (15 min average)",
       "fieldConfig": {
@@ -304,9 +300,7 @@
         "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -319,7 +313,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "avg(node_load15{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}) /  count(count(node_cpu_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}) by (cpu)) * 100",
           "hide": false,
@@ -334,7 +328,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Non available RAM memory",
       "fieldConfig": {
@@ -379,9 +373,7 @@
         "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -394,7 +386,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "((node_memory_MemTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_MemFree_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}) / (node_memory_MemTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} )) * 100",
           "format": "time_series",
@@ -406,7 +398,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "100 - ((node_memory_MemAvailable_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} * 100) / node_memory_MemTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"})",
           "format": "time_series",
@@ -422,7 +414,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Used Swap",
       "fieldConfig": {
@@ -476,9 +468,7 @@
         "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -491,7 +481,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "((node_memory_SwapTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_SwapFree_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}) / (node_memory_SwapTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} )) * 100",
           "intervalFactor": 1,
@@ -505,7 +495,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Used Root FS",
       "fieldConfig": {
@@ -559,9 +549,7 @@
         "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -574,7 +562,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "100 - ((node_filesystem_avail_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",mountpoint=\"/\",fstype!=\"rootfs\"} * 100) / node_filesystem_size_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",mountpoint=\"/\",fstype!=\"rootfs\"})",
           "format": "time_series",
@@ -589,7 +577,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Total number of CPU cores",
       "fieldConfig": {
@@ -640,9 +628,7 @@
         "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -655,7 +641,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "count(count(node_cpu_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}) by (cpu))",
           "interval": "",
@@ -671,7 +657,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "System uptime",
       "fieldConfig": {
@@ -723,9 +709,7 @@
         "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -738,7 +722,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "node_time_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_boot_time_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
@@ -755,7 +739,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Total SWAP",
       "fieldConfig": {
@@ -807,9 +791,7 @@
         "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -822,7 +804,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "node_memory_SwapTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
           "intervalFactor": 1,
@@ -836,7 +818,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Total RootFS",
       "fieldConfig": {
@@ -892,9 +874,7 @@
         "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -907,7 +887,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "node_filesystem_size_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",mountpoint=\"/\",fstype!=\"rootfs\"}",
@@ -926,7 +906,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Total data disk capacity",
       "fieldConfig": {
@@ -982,9 +962,7 @@
         "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -997,7 +975,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "node_filesystem_size_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",mountpoint=\"/data\",fstype!=\"rootfs\"}",
@@ -1017,7 +995,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Total RAM",
       "fieldConfig": {
@@ -1069,9 +1047,7 @@
         "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -1084,7 +1060,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "node_memory_MemTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
           "intervalFactor": 1,
@@ -1111,7 +1087,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Basic CPU info",
       "fieldConfig": {
@@ -1485,7 +1461,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode=\"system\",supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
           "format": "time_series",
@@ -1498,7 +1474,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode='user',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
           "format": "time_series",
@@ -1511,7 +1487,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode='iowait',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
           "format": "time_series",
@@ -1523,7 +1499,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode=~\".*irq\",supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
           "format": "time_series",
@@ -1535,7 +1511,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "sum (rate(node_cpu_seconds_total{mode!='idle',mode!='user',mode!='system',mode!='iowait',mode!='irq',mode!='softirq',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
           "format": "time_series",
@@ -1547,7 +1523,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='idle',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
           "format": "time_series",
@@ -1563,7 +1539,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Basic memory usage",
       "fieldConfig": {
@@ -2020,7 +1996,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "node_memory_MemTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
           "format": "time_series",
@@ -2033,7 +2009,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "node_memory_MemTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_MemFree_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - (node_memory_Cached_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} + node_memory_Buffers_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"})",
           "format": "time_series",
@@ -2046,7 +2022,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "node_memory_Cached_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} + node_memory_Buffers_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
           "format": "time_series",
@@ -2058,7 +2034,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "node_memory_MemFree_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
           "format": "time_series",
@@ -2070,7 +2046,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "(node_memory_SwapTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_SwapFree_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"})",
           "format": "time_series",
@@ -2086,7 +2062,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Basic network info per interface",
       "fieldConfig": {
@@ -2530,7 +2506,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "rate(node_network_receive_bytes_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])*8",
           "format": "time_series",
@@ -2542,7 +2518,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "rate(node_network_transmit_bytes_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])*8",
           "format": "time_series",
@@ -2558,7 +2534,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Disk space used of all filesystems mounted",
       "fieldConfig": {
@@ -2658,7 +2634,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "expr": "100 - ((node_filesystem_avail_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'} * 100) / node_filesystem_size_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'})",
           "format": "time_series",
@@ -2687,7 +2663,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Disk space used by the database",
       "fieldConfig": {
@@ -2770,7 +2746,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "pg_database_size_mb{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
@@ -2788,7 +2764,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Active number of client connections",
       "fieldConfig": {
@@ -2884,7 +2860,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "pg_stat_database_num_backends{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
@@ -2898,7 +2874,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "sum(supavisor_connections_active{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"})",
@@ -2912,7 +2888,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "pgbouncer_used_clients{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
@@ -2927,7 +2903,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "sum by (Name) (pgbouncer_pools_client_waiting_connections{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"})",
@@ -2946,7 +2922,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -3004,9 +2980,7 @@
         "orientation": "auto",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -3020,7 +2994,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "pg_up{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
@@ -3035,7 +3009,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -3093,9 +3067,7 @@
         "orientation": "auto",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -3109,7 +3081,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "pgbouncer_up{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
@@ -3124,7 +3096,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "",
       "fieldConfig": {
@@ -3227,7 +3199,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "rate(supabase_usage_metrics_user_queries_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -3241,7 +3213,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_statements_total_queries{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -3253,7 +3225,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_statements_total_time_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -3270,7 +3242,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "",
       "fieldConfig": {
@@ -3370,7 +3342,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_database_xact_commit_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -3384,7 +3356,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_database_xact_rollback_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -3399,7 +3371,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_database_deadlocks_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -3418,7 +3390,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "",
       "fieldConfig": {
@@ -3521,7 +3493,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_database_conflicts_confl_tablespace_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -3535,7 +3507,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_database_conflicts_confl_lock_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -3550,7 +3522,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_database_conflicts_confl_snapshot_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -3565,7 +3537,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_database_conflicts_confl_bufferpin_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -3580,7 +3552,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_database_conflicts_confl_deadlock_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -3599,7 +3571,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -3658,9 +3630,7 @@
         "orientation": "auto",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "limit": 2,
           "values": false
@@ -3675,7 +3645,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "pg_settings_default_transaction_read_only{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
@@ -3691,7 +3661,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -3750,9 +3720,7 @@
         "orientation": "auto",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
+          "calcs": ["last"],
           "fields": "",
           "values": false
         },
@@ -3766,7 +3734,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "pg_status_in_recovery{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
@@ -3794,7 +3762,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Realtime replication status",
       "fieldConfig": {
@@ -3853,9 +3821,7 @@
         "orientation": "auto",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -3869,7 +3835,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "replication_realtime_slot_status{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
@@ -3884,7 +3850,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "",
       "fieldConfig": {
@@ -3966,7 +3932,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "replication_realtime_lag_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
@@ -3997,7 +3963,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "",
       "fieldConfig": {
@@ -4088,7 +4054,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_bgwriter_checkpoints_timed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -4102,7 +4068,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_bgwriter_checkpoints_req_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -4117,7 +4083,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_bgwriter_checkpoint_write_time_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -4132,7 +4098,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_bgwriter_checkpoint_sync_time_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -4151,7 +4117,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "",
       "fieldConfig": {
@@ -4238,7 +4204,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_bgwriter_buffers_checkpoint_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -4252,7 +4218,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_bgwriter_buffers_clean_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -4267,7 +4233,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_bgwriter_buffers_backend_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -4282,7 +4248,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_bgwriter_buffers_alloc_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -4301,7 +4267,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "",
       "fieldConfig": {
@@ -4388,7 +4354,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_bgwriter_maxwritten_clean_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -4402,7 +4368,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_bgwriter_buffers_backend_fsync_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -4431,7 +4397,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -4457,7 +4423,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode=\"system\",supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
               "format": "time_series",
@@ -4470,7 +4436,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='user',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
               "format": "time_series",
@@ -4482,7 +4448,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='nice',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
               "format": "time_series",
@@ -4494,7 +4460,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='idle',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
               "format": "time_series",
@@ -4506,7 +4472,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='iowait',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
               "format": "time_series",
@@ -4518,7 +4484,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='irq',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
               "format": "time_series",
@@ -4530,7 +4496,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='softirq',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
               "format": "time_series",
@@ -4542,7 +4508,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='steal',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
               "format": "time_series",
@@ -4554,7 +4520,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='guest',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
               "format": "time_series",
@@ -4570,7 +4536,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -4596,7 +4562,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_MemTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_MemFree_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_Buffers_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_Cached_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_Slab_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_PageTables_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_SwapCached_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -4609,7 +4575,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_PageTables_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -4622,7 +4588,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_SwapCached_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -4634,7 +4600,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_Slab_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -4647,7 +4613,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_Cached_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -4660,7 +4626,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_Buffers_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -4673,7 +4639,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_MemFree_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -4686,7 +4652,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "(node_memory_SwapTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_SwapFree_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"})",
               "format": "time_series",
@@ -4699,7 +4665,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_HardwareCorrupted_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -4716,7 +4682,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -4740,7 +4706,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_network_receive_bytes_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])*8",
               "format": "time_series",
@@ -4752,7 +4718,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_network_transmit_bytes_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])*8",
               "format": "time_series",
@@ -4768,7 +4734,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -4794,7 +4760,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_filesystem_size_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'} - node_filesystem_avail_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'}",
               "format": "time_series",
@@ -4810,7 +4776,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -4836,7 +4802,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_disk_reads_completed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device=~\"$diskdevices\"}[$__rate_interval])",
               "intervalFactor": 1,
@@ -4847,7 +4813,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_disk_writes_completed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device=~\"$diskdevices\"}[$__rate_interval])",
               "intervalFactor": 1,
@@ -4862,7 +4828,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -4888,7 +4854,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_disk_read_bytes_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device=~\"$diskdevices\"}[$__rate_interval])",
               "format": "time_series",
@@ -4901,7 +4867,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_disk_written_bytes_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device=~\"$diskdevices\"}[$__rate_interval])",
               "format": "time_series",
@@ -4918,7 +4884,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -4944,7 +4910,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_disk_io_time_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device=~\"$diskdevices\"} [$__rate_interval])",
               "format": "time_series",
@@ -4976,7 +4942,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -4997,7 +4963,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_Inactive_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5009,7 +4975,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_Active_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5025,7 +4991,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5046,7 +5012,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_Committed_AS_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5058,7 +5024,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_CommitLimit_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5074,7 +5040,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5095,7 +5061,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_Inactive_file_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5108,7 +5074,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_Inactive_anon_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5121,7 +5087,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_Active_file_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5134,7 +5100,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_Active_anon_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5151,7 +5117,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5172,7 +5138,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_Writeback_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5184,7 +5150,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_WritebackTmp_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5196,7 +5162,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_Dirty_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5212,7 +5178,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5233,7 +5199,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_Mapped_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5245,7 +5211,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_Shmem_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5257,7 +5223,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_ShmemHugePages_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5270,7 +5236,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_ShmemPmdMapped_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5287,7 +5253,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5308,7 +5274,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_SUnreclaim_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5320,7 +5286,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_SReclaimable_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5336,7 +5302,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5357,7 +5323,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_VmallocChunk_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5370,7 +5336,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_VmallocTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5383,7 +5349,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_VmallocUsed_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5400,7 +5366,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5421,7 +5387,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_Bounce_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5437,7 +5403,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5458,7 +5424,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_AnonHugePages_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5470,7 +5436,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_AnonPages_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5486,7 +5452,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5507,7 +5473,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_KernelStack_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5519,7 +5485,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_Percpu_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5536,7 +5502,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5557,7 +5523,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_HugePages_Free{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5569,7 +5535,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_HugePages_Rsvd{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5581,7 +5547,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_HugePages_Surp{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5597,7 +5563,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5618,7 +5584,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_HugePages_Total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5630,7 +5596,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_Hugepagesize_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5646,7 +5612,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5667,7 +5633,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_DirectMap1G_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5679,7 +5645,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_DirectMap2M_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5692,7 +5658,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_DirectMap4k_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5709,7 +5675,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5730,7 +5696,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_Unevictable_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5742,7 +5708,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_Mlocked_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5758,7 +5724,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5779,7 +5745,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_memory_NFS_Unstable_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5809,7 +5775,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5830,7 +5796,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_vmstat_pgpgin{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -5842,7 +5808,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_vmstat_pgpgout{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -5858,7 +5824,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5879,7 +5845,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_vmstat_pswpin{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -5891,7 +5857,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_vmstat_pswpout{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -5907,7 +5873,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5928,7 +5894,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_vmstat_pgfault{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -5940,7 +5906,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_vmstat_pgmajfault{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -5952,7 +5918,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_vmstat_pgfault{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])  - rate(node_vmstat_pgmajfault{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -5968,7 +5934,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5989,7 +5955,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_vmstat_oom_kill{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -6020,7 +5986,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -6041,7 +6007,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_timex_estimated_error_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6055,7 +6021,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_timex_offset_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6069,7 +6035,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_timex_maxerror_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6087,7 +6053,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -6108,7 +6074,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_timex_loop_time_constant{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6125,7 +6091,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -6146,7 +6112,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_timex_sync_status{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6159,7 +6125,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_timex_frequency_adjustment_ratio{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6176,7 +6142,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -6197,7 +6163,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_timex_tick_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6210,7 +6176,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_timex_tai_offset_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6241,7 +6207,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -6262,7 +6228,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_procs_blocked{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6274,7 +6240,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_procs_running{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6290,7 +6256,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -6311,7 +6277,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_processes_state{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6328,7 +6294,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -6349,7 +6315,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_forks_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -6366,7 +6332,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -6386,7 +6352,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(process_virtual_memory_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "hide": false,
@@ -6399,7 +6365,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "process_resident_memory_max_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "hide": false,
@@ -6412,7 +6378,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(process_virtual_memory_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "hide": false,
@@ -6425,7 +6391,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(process_virtual_memory_max_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "hide": false,
@@ -6442,7 +6408,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -6463,7 +6429,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_processes_pids{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6476,7 +6442,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_processes_max_processes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6493,7 +6459,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -6514,7 +6480,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_schedstat_running_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -6527,7 +6493,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_schedstat_waiting_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -6544,7 +6510,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -6565,7 +6531,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_processes_threads{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6578,7 +6544,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_processes_max_threads{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6609,7 +6575,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -6630,7 +6596,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_context_switches_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -6642,7 +6608,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_intr_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -6659,7 +6625,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -6680,7 +6646,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_load1{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6692,7 +6658,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_load5{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6704,7 +6670,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_load15{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6720,7 +6686,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -6740,7 +6706,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_interrupts_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -6757,7 +6723,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -6778,7 +6744,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_schedstat_timeslices_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -6795,7 +6761,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -6816,7 +6782,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_entropy_available_bits{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6832,7 +6798,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -6853,7 +6819,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(process_cpu_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -6870,7 +6836,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -6890,7 +6856,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "process_max_fds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "interval": "",
@@ -6902,7 +6868,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "process_open_fds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "interval": "",
@@ -6932,7 +6898,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -6952,7 +6918,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_hwmon_temp_celsius{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6965,7 +6931,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_hwmon_temp_crit_alarm_celsius{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6979,7 +6945,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_hwmon_temp_crit_celsius{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6992,7 +6958,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_hwmon_temp_crit_hyst_celsius{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -7006,7 +6972,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_hwmon_temp_max_celsius{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -7024,7 +6990,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -7044,7 +7010,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_cooling_device_cur_state{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -7058,7 +7024,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_cooling_device_max_state{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -7075,7 +7041,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -7095,7 +7061,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_power_supply_online{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -7127,7 +7093,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -7147,7 +7113,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_systemd_socket_accepted_connections_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -7164,7 +7130,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -7184,7 +7150,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_systemd_units{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",state=\"activating\"}",
               "format": "time_series",
@@ -7197,7 +7163,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_systemd_units{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",state=\"active\"}",
               "format": "time_series",
@@ -7210,7 +7176,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_systemd_units{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",state=\"deactivating\"}",
               "format": "time_series",
@@ -7223,7 +7189,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_systemd_units{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",state=\"failed\"}",
               "format": "time_series",
@@ -7236,7 +7202,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_systemd_units{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",state=\"inactive\"}",
               "format": "time_series",
@@ -7267,7 +7233,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "The number (after merges) of I/O requests completed per second for the device",
           "fieldConfig": {
@@ -7293,7 +7259,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_disk_reads_completed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "intervalFactor": 1,
@@ -7304,7 +7270,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_disk_writes_completed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "intervalFactor": 1,
@@ -7319,7 +7285,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "The number of bytes read from or written to the device per second",
           "fieldConfig": {
@@ -7345,7 +7311,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_disk_read_bytes_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -7357,7 +7323,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_disk_written_bytes_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -7373,7 +7339,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "The average time for requests issued to the device to be served. This includes the time spent by the requests in queue and the time spent servicing them.",
           "fieldConfig": {
@@ -7399,7 +7365,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_disk_read_time_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval]) / rate(node_disk_reads_completed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "hide": false,
@@ -7412,7 +7378,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_disk_write_time_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval]) / rate(node_disk_writes_completed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "hide": false,
@@ -7429,7 +7395,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "The average queue length of the requests that were issued to the device",
           "fieldConfig": {
@@ -7455,7 +7421,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_disk_io_time_weighted_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "interval": "",
@@ -7471,7 +7437,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "The number of read and write requests merged per second that were queued to the device",
           "fieldConfig": {
@@ -7497,7 +7463,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_disk_reads_merged_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "intervalFactor": 1,
@@ -7508,7 +7474,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_disk_writes_merged_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "intervalFactor": 1,
@@ -7523,7 +7489,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Percentage of elapsed time during which I/O requests were issued to the device (bandwidth utilization for the device). Device saturation occurs when this value is close to 100% for devices serving requests serially.  But for devices  serving requests in parallel, such as RAID arrays and modern SSDs, this number does not reflect their performance limits.",
           "fieldConfig": {
@@ -7549,7 +7515,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_disk_io_time_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "interval": "",
@@ -7561,7 +7527,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_disk_discard_time_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "interval": "",
@@ -7577,7 +7543,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "The number of outstanding requests at the instant the sample was taken. Incremented as requests are given to appropriate struct request_queue and decremented as they finish.",
           "fieldConfig": {
@@ -7603,7 +7569,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_disk_io_now{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"})",
               "interval": "",
@@ -7619,7 +7585,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -7645,7 +7611,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_disk_discards_completed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "interval": "",
@@ -7657,7 +7623,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_disk_discards_merged_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "interval": "",
@@ -7687,7 +7653,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -7713,7 +7679,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_filesystem_avail_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'}",
               "format": "time_series",
@@ -7727,7 +7693,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_filesystem_free_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'}",
               "format": "time_series",
@@ -7740,7 +7706,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_filesystem_size_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'}",
               "format": "time_series",
@@ -7757,7 +7723,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -7782,7 +7748,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_filesystem_files_free{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'}",
               "format": "time_series",
@@ -7799,7 +7765,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -7825,7 +7791,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_filefd_maximum{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -7837,7 +7803,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_filefd_allocated{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -7853,7 +7819,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -7878,7 +7844,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_filesystem_files{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'}",
               "format": "time_series",
@@ -7895,7 +7861,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -7921,7 +7887,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_filesystem_readonly{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'}",
               "format": "time_series",
@@ -7933,7 +7899,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_filesystem_device_error{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs',fstype!~'tmpfs'}",
               "format": "time_series",
@@ -7964,7 +7930,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -7984,7 +7950,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_network_receive_packets_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -7997,7 +7963,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_network_transmit_packets_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -8014,7 +7980,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -8034,7 +8000,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_network_receive_errs_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -8046,7 +8012,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_network_transmit_errs_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -8062,7 +8028,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -8082,7 +8048,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_network_receive_drop_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -8094,7 +8060,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_network_transmit_drop_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -8110,7 +8076,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -8130,7 +8096,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_network_receive_compressed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -8142,7 +8108,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_network_transmit_compressed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -8158,7 +8124,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -8178,7 +8144,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_network_receive_multicast_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -8194,7 +8160,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -8214,7 +8180,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_network_receive_fifo_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -8226,7 +8192,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_network_transmit_fifo_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -8242,7 +8208,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -8262,7 +8228,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_network_receive_frame_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -8279,7 +8245,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -8299,7 +8265,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_network_transmit_carrier_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -8315,7 +8281,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -8335,7 +8301,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_network_transmit_colls_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -8351,7 +8317,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -8371,7 +8337,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_nf_conntrack_entries{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8383,7 +8349,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_nf_conntrack_entries_limit{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8399,7 +8365,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -8419,7 +8385,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_arp_entries{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8435,7 +8401,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -8455,7 +8421,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_network_mtu_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8471,7 +8437,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -8491,7 +8457,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_network_speed_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8507,7 +8473,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -8527,7 +8493,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_network_transmit_queue_length{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8543,7 +8509,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -8563,7 +8529,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_softnet_processed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -8576,7 +8542,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_softnet_dropped_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -8593,7 +8559,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -8613,7 +8579,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_softnet_times_squeezed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -8630,7 +8596,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {},
@@ -8650,7 +8616,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_network_up{operstate=\"up\",supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8662,7 +8628,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_network_carrier{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8691,7 +8657,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -8715,7 +8681,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_sockstat_TCP_alloc{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8728,7 +8694,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_sockstat_TCP_inuse{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8741,7 +8707,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_sockstat_TCP_mem{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8755,7 +8721,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_sockstat_TCP_orphan{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8768,7 +8734,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_sockstat_TCP_tw{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8785,7 +8751,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -8809,7 +8775,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_sockstat_UDPLITE_inuse{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8822,7 +8788,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_sockstat_UDP_inuse{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8835,7 +8801,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_sockstat_UDP_mem{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8852,7 +8818,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -8876,7 +8842,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_sockstat_FRAG_inuse{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8889,7 +8855,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_sockstat_RAW_inuse{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8906,7 +8872,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -8930,7 +8896,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_sockstat_TCP_mem_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8943,7 +8909,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_sockstat_UDP_mem_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8956,7 +8922,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_sockstat_FRAG_memory{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "interval": "",
@@ -8971,7 +8937,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -8995,7 +8961,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_sockstat_sockets_used{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -9026,7 +8992,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -9051,7 +9017,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_netstat_IpExt_InOctets{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9064,7 +9030,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_netstat_IpExt_OutOctets{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9080,7 +9046,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -9104,7 +9070,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_netstat_Ip_Forwarding{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9121,7 +9087,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -9146,7 +9112,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_netstat_Icmp_InMsgs{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9159,7 +9125,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_netstat_Icmp_OutMsgs{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9176,7 +9142,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -9201,7 +9167,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_netstat_Icmp_InErrors{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9218,7 +9184,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -9243,7 +9209,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_netstat_Udp_InDatagrams{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9256,7 +9222,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_netstat_Udp_OutDatagrams{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9273,7 +9239,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -9298,7 +9264,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_netstat_Udp_InErrors{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9311,7 +9277,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_netstat_Udp_NoPorts{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9324,7 +9290,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_netstat_UdpLite_InErrors{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "interval": "",
@@ -9334,7 +9300,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_netstat_Udp_RcvbufErrors{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9347,7 +9313,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_netstat_Udp_SndbufErrors{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9364,7 +9330,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -9389,7 +9355,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_netstat_Tcp_InSegs{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9403,7 +9369,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_netstat_Tcp_OutSegs{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9420,7 +9386,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -9446,7 +9412,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_netstat_TcpExt_ListenOverflows{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9460,7 +9426,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_netstat_TcpExt_ListenDrops{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9474,7 +9440,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_netstat_TcpExt_TCPSynRetrans{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9487,7 +9453,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_netstat_Tcp_RetransSegs{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "interval": "",
@@ -9497,7 +9463,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_netstat_Tcp_InErrs{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "interval": "",
@@ -9507,7 +9473,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_netstat_Tcp_OutRsts{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "interval": "",
@@ -9521,7 +9487,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -9546,7 +9512,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_netstat_Tcp_CurrEstab{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -9560,7 +9526,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_netstat_Tcp_MaxConn{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -9578,7 +9544,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -9604,7 +9570,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_netstat_TcpExt_SyncookiesFailed{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9618,7 +9584,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_netstat_TcpExt_SyncookiesRecv{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9632,7 +9598,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_netstat_TcpExt_SyncookiesSent{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9650,7 +9616,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -9675,7 +9641,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_netstat_Tcp_ActiveOpens{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9688,7 +9654,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "rate(node_netstat_Tcp_PassiveOpens{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9719,7 +9685,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -9740,7 +9706,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_scrape_collector_duration_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -9758,7 +9724,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "",
           "fieldConfig": {
@@ -9779,7 +9745,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_scrape_collector_success{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -9793,7 +9759,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "node_textfile_scrape_error{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -9822,7 +9788,7 @@
         "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          "uid": "${DS_PROMETHEUS}"
         },
         "definition": "label_values(supabase_project_ref)",
         "includeAll": false,
@@ -9860,7 +9826,7 @@
         "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_GRAFANACLOUD-ENCIMA-PROM}"
+          "uid": "${DS_PROMETHEUS}"
         },
         "definition": "label_values(supabase_identifier)",
         "includeAll": false,

--- a/grafana/dashboard.json
+++ b/grafana/dashboard.json
@@ -37,7 +37,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "prometheus"
       },
       "description": "Busy state of all CPU cores together",
       "fieldConfig": {
@@ -91,9 +91,7 @@
         "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -106,7 +104,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "expr": "clamp_min(100 - (avg(rate(node_cpu_seconds_total{mode=\"idle\", supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) by (instance) * 100), 0)",
           "hide": false,
@@ -122,7 +120,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "prometheus"
       },
       "description": "Busy state of all CPU cores together (5 min average)",
       "fieldConfig": {
@@ -176,9 +174,7 @@
         "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -191,7 +187,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "expr": "avg(node_load5{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}) /  count(count(node_cpu_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}) by (cpu)) * 100",
           "format": "time_series",
@@ -207,7 +203,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "prometheus"
       },
       "description": "Busy state of all CPU cores together (15 min average)",
       "fieldConfig": {
@@ -261,9 +257,7 @@
         "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -276,7 +270,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "expr": "avg(node_load15{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}) /  count(count(node_cpu_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}) by (cpu)) * 100",
           "hide": false,
@@ -291,7 +285,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "prometheus"
       },
       "description": "Non available RAM memory",
       "fieldConfig": {
@@ -336,9 +330,7 @@
         "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -351,7 +343,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "expr": "((node_memory_MemTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_MemFree_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}) / (node_memory_MemTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} )) * 100",
           "format": "time_series",
@@ -363,7 +355,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "expr": "100 - ((node_memory_MemAvailable_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} * 100) / node_memory_MemTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"})",
           "format": "time_series",
@@ -379,7 +371,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "prometheus"
       },
       "description": "Used Swap",
       "fieldConfig": {
@@ -433,9 +425,7 @@
         "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -448,7 +438,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "expr": "((node_memory_SwapTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_SwapFree_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}) / (node_memory_SwapTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} )) * 100",
           "intervalFactor": 1,
@@ -462,7 +452,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "prometheus"
       },
       "description": "Used Root FS",
       "fieldConfig": {
@@ -516,9 +506,7 @@
         "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -531,7 +519,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "expr": "100 - ((node_filesystem_avail_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",mountpoint=\"/\",fstype!=\"rootfs\"} * 100) / node_filesystem_size_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",mountpoint=\"/\",fstype!=\"rootfs\"})",
           "format": "time_series",
@@ -546,7 +534,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "prometheus"
       },
       "description": "Total number of CPU cores",
       "fieldConfig": {
@@ -597,9 +585,7 @@
         "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -612,7 +598,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "expr": "count(count(node_cpu_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}) by (cpu))",
           "interval": "",
@@ -628,7 +614,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "prometheus"
       },
       "description": "System uptime",
       "fieldConfig": {
@@ -680,9 +666,7 @@
         "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -695,7 +679,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "node_time_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_boot_time_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
@@ -712,7 +696,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "prometheus"
       },
       "description": "Total SWAP",
       "fieldConfig": {
@@ -764,9 +748,7 @@
         "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -779,7 +761,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "expr": "node_memory_SwapTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
           "intervalFactor": 1,
@@ -793,7 +775,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "prometheus"
       },
       "description": "Total RootFS",
       "fieldConfig": {
@@ -849,9 +831,7 @@
         "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -864,7 +844,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "node_filesystem_size_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",mountpoint=\"/\",fstype!=\"rootfs\"}",
@@ -883,7 +863,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "prometheus"
       },
       "description": "Total data disk capacity",
       "fieldConfig": {
@@ -939,9 +919,7 @@
         "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -954,7 +932,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "node_filesystem_size_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",mountpoint=\"/data\",fstype!=\"rootfs\"}",
@@ -974,7 +952,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "prometheus"
       },
       "description": "Total RAM",
       "fieldConfig": {
@@ -1026,9 +1004,7 @@
         "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -1041,7 +1017,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "expr": "node_memory_MemTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
           "intervalFactor": 1,
@@ -1068,7 +1044,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "prometheus"
       },
       "description": "Basic CPU info",
       "fieldConfig": {
@@ -1442,7 +1418,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode=\"system\",supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
           "format": "time_series",
@@ -1455,7 +1431,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode='user',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
           "format": "time_series",
@@ -1468,7 +1444,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode='iowait',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
           "format": "time_series",
@@ -1480,7 +1456,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode=~\".*irq\",supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
           "format": "time_series",
@@ -1492,7 +1468,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "expr": "sum (rate(node_cpu_seconds_total{mode!='idle',mode!='user',mode!='system',mode!='iowait',mode!='irq',mode!='softirq',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
           "format": "time_series",
@@ -1504,7 +1480,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='idle',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
           "format": "time_series",
@@ -1520,7 +1496,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "prometheus"
       },
       "description": "Basic memory usage",
       "fieldConfig": {
@@ -1977,7 +1953,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "expr": "node_memory_MemTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
           "format": "time_series",
@@ -1990,7 +1966,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "expr": "node_memory_MemTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_MemFree_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - (node_memory_Cached_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} + node_memory_Buffers_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"})",
           "format": "time_series",
@@ -2003,7 +1979,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "expr": "node_memory_Cached_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} + node_memory_Buffers_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
           "format": "time_series",
@@ -2015,7 +1991,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "expr": "node_memory_MemFree_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
           "format": "time_series",
@@ -2027,7 +2003,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "expr": "(node_memory_SwapTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_SwapFree_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"})",
           "format": "time_series",
@@ -2043,7 +2019,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "prometheus"
       },
       "description": "Basic network info per interface",
       "fieldConfig": {
@@ -2487,7 +2463,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "expr": "rate(node_network_receive_bytes_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])*8",
           "format": "time_series",
@@ -2499,7 +2475,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "expr": "rate(node_network_transmit_bytes_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])*8",
           "format": "time_series",
@@ -2515,7 +2491,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "prometheus"
       },
       "description": "Disk space used of all filesystems mounted",
       "fieldConfig": {
@@ -2615,7 +2591,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "expr": "100 - ((node_filesystem_avail_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'} * 100) / node_filesystem_size_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'})",
           "format": "time_series",
@@ -2644,7 +2620,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "prometheus"
       },
       "description": "Disk space used by the database",
       "fieldConfig": {
@@ -2727,7 +2703,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "pg_database_size_mb{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
@@ -2745,7 +2721,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "prometheus"
       },
       "description": "Active number of client connections",
       "fieldConfig": {
@@ -2841,7 +2817,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "pg_stat_database_num_backends{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
@@ -2855,7 +2831,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "sum(supavisor_connections_active{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"})",
@@ -2869,7 +2845,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "pgbouncer_used_clients{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
@@ -2884,7 +2860,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "sum by (Name) (pgbouncer_pools_client_waiting_connections{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"})",
@@ -2903,7 +2879,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -2961,9 +2937,7 @@
         "orientation": "auto",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -2977,7 +2951,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "pg_up{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
@@ -2992,7 +2966,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -3050,9 +3024,7 @@
         "orientation": "auto",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -3066,7 +3038,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "pgbouncer_up{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
@@ -3081,7 +3053,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "prometheus"
       },
       "description": "",
       "fieldConfig": {
@@ -3184,7 +3156,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "rate(supabase_usage_metrics_user_queries_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -3198,7 +3170,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_statements_total_queries{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -3210,7 +3182,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_statements_total_time_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -3227,7 +3199,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "prometheus"
       },
       "description": "",
       "fieldConfig": {
@@ -3327,7 +3299,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_database_xact_commit_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -3341,7 +3313,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_database_xact_rollback_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -3356,7 +3328,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_database_deadlocks_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -3375,7 +3347,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "prometheus"
       },
       "description": "",
       "fieldConfig": {
@@ -3478,7 +3450,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_database_conflicts_confl_tablespace_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -3492,7 +3464,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_database_conflicts_confl_lock_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -3507,7 +3479,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_database_conflicts_confl_snapshot_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -3522,7 +3494,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_database_conflicts_confl_bufferpin_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -3537,7 +3509,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_database_conflicts_confl_deadlock_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -3556,7 +3528,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -3615,9 +3587,7 @@
         "orientation": "auto",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "limit": 2,
           "values": false
@@ -3632,7 +3602,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "pg_settings_default_transaction_read_only{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
@@ -3648,7 +3618,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -3707,9 +3677,7 @@
         "orientation": "auto",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
+          "calcs": ["last"],
           "fields": "",
           "values": false
         },
@@ -3723,7 +3691,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "pg_status_in_recovery{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
@@ -3751,7 +3719,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "prometheus"
       },
       "description": "Realtime replication status",
       "fieldConfig": {
@@ -3810,9 +3778,7 @@
         "orientation": "auto",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -3826,7 +3792,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "replication_realtime_slot_status{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
@@ -3841,7 +3807,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "prometheus"
       },
       "description": "",
       "fieldConfig": {
@@ -3923,7 +3889,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "replication_realtime_lag_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
@@ -3954,7 +3920,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "prometheus"
       },
       "description": "",
       "fieldConfig": {
@@ -4045,7 +4011,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_bgwriter_checkpoints_timed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -4059,7 +4025,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_bgwriter_checkpoints_req_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -4074,7 +4040,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_bgwriter_checkpoint_write_time_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -4089,7 +4055,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_bgwriter_checkpoint_sync_time_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -4108,7 +4074,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "prometheus"
       },
       "description": "",
       "fieldConfig": {
@@ -4195,7 +4161,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_bgwriter_buffers_checkpoint_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -4209,7 +4175,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_bgwriter_buffers_clean_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -4224,7 +4190,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_bgwriter_buffers_backend_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -4239,7 +4205,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_bgwriter_buffers_alloc_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -4258,7 +4224,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "grafanacloud-prom"
+        "uid": "prometheus"
       },
       "description": "",
       "fieldConfig": {
@@ -4345,7 +4311,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_bgwriter_maxwritten_clean_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -4359,7 +4325,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "exemplar": false,
           "expr": "rate(pg_stat_bgwriter_buffers_backend_fsync_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
@@ -4388,7 +4354,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "description": "",
           "fieldConfig": {
@@ -4414,7 +4380,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode=\"system\",supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
               "format": "time_series",
@@ -4427,7 +4393,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='user',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
               "format": "time_series",
@@ -4439,7 +4405,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='nice',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
               "format": "time_series",
@@ -4451,7 +4417,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='idle',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
               "format": "time_series",
@@ -4463,7 +4429,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='iowait',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
               "format": "time_series",
@@ -4475,7 +4441,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='irq',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
               "format": "time_series",
@@ -4487,7 +4453,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='softirq',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
               "format": "time_series",
@@ -4499,7 +4465,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='steal',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
               "format": "time_series",
@@ -4511,7 +4477,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='guest',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
               "format": "time_series",
@@ -4527,7 +4493,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "description": "",
           "fieldConfig": {
@@ -4553,7 +4519,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_MemTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_MemFree_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_Buffers_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_Cached_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_Slab_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_PageTables_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_SwapCached_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -4566,7 +4532,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_PageTables_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -4579,7 +4545,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_SwapCached_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -4591,7 +4557,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_Slab_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -4604,7 +4570,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_Cached_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -4617,7 +4583,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_Buffers_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -4630,7 +4596,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_MemFree_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -4643,7 +4609,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "(node_memory_SwapTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_SwapFree_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"})",
               "format": "time_series",
@@ -4656,7 +4622,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_HardwareCorrupted_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -4673,7 +4639,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -4697,7 +4663,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_network_receive_bytes_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])*8",
               "format": "time_series",
@@ -4709,7 +4675,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_network_transmit_bytes_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])*8",
               "format": "time_series",
@@ -4725,7 +4691,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "description": "",
           "fieldConfig": {
@@ -4751,7 +4717,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_filesystem_size_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'} - node_filesystem_avail_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'}",
               "format": "time_series",
@@ -4767,7 +4733,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "description": "",
           "fieldConfig": {
@@ -4793,7 +4759,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_disk_reads_completed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device=~\"$diskdevices\"}[$__rate_interval])",
               "intervalFactor": 1,
@@ -4804,7 +4770,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_disk_writes_completed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device=~\"$diskdevices\"}[$__rate_interval])",
               "intervalFactor": 1,
@@ -4819,7 +4785,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "description": "",
           "fieldConfig": {
@@ -4845,7 +4811,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_disk_read_bytes_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device=~\"$diskdevices\"}[$__rate_interval])",
               "format": "time_series",
@@ -4858,7 +4824,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_disk_written_bytes_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device=~\"$diskdevices\"}[$__rate_interval])",
               "format": "time_series",
@@ -4875,7 +4841,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "description": "",
           "fieldConfig": {
@@ -4901,7 +4867,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_disk_io_time_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device=~\"$diskdevices\"} [$__rate_interval])",
               "format": "time_series",
@@ -4933,7 +4899,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -4954,7 +4920,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_Inactive_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -4966,7 +4932,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_Active_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -4982,7 +4948,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5003,7 +4969,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_Committed_AS_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5015,7 +4981,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_CommitLimit_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5031,7 +4997,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5052,7 +5018,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_Inactive_file_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5065,7 +5031,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_Inactive_anon_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5078,7 +5044,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_Active_file_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5091,7 +5057,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_Active_anon_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5108,7 +5074,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5129,7 +5095,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_Writeback_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5141,7 +5107,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_WritebackTmp_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5153,7 +5119,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_Dirty_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5169,7 +5135,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5190,7 +5156,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_Mapped_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5202,7 +5168,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_Shmem_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5214,7 +5180,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_ShmemHugePages_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5227,7 +5193,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_ShmemPmdMapped_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5244,7 +5210,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5265,7 +5231,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_SUnreclaim_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5277,7 +5243,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_SReclaimable_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5293,7 +5259,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5314,7 +5280,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_VmallocChunk_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5327,7 +5293,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_VmallocTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5340,7 +5306,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_VmallocUsed_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5357,7 +5323,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5378,7 +5344,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_Bounce_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5394,7 +5360,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5415,7 +5381,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_AnonHugePages_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5427,7 +5393,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_AnonPages_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5443,7 +5409,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5464,7 +5430,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_KernelStack_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5476,7 +5442,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_Percpu_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5493,7 +5459,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5514,7 +5480,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_HugePages_Free{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5526,7 +5492,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_HugePages_Rsvd{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5538,7 +5504,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_HugePages_Surp{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5554,7 +5520,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5575,7 +5541,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_HugePages_Total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5587,7 +5553,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_Hugepagesize_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5603,7 +5569,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5624,7 +5590,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_DirectMap1G_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5636,7 +5602,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_DirectMap2M_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5649,7 +5615,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_DirectMap4k_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5666,7 +5632,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5687,7 +5653,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_Unevictable_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5699,7 +5665,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_Mlocked_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5715,7 +5681,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5736,7 +5702,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_memory_NFS_Unstable_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -5766,7 +5732,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5787,7 +5753,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_vmstat_pgpgin{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -5799,7 +5765,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_vmstat_pgpgout{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -5815,7 +5781,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5836,7 +5802,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_vmstat_pswpin{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -5848,7 +5814,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_vmstat_pswpout{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -5864,7 +5830,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5885,7 +5851,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_vmstat_pgfault{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -5897,7 +5863,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_vmstat_pgmajfault{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -5909,7 +5875,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_vmstat_pgfault{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])  - rate(node_vmstat_pgmajfault{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -5925,7 +5891,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -5946,7 +5912,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_vmstat_oom_kill{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -5977,7 +5943,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "description": "",
           "fieldConfig": {
@@ -5998,7 +5964,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_timex_estimated_error_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6012,7 +5978,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_timex_offset_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6026,7 +5992,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_timex_maxerror_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6044,7 +6010,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "description": "",
           "fieldConfig": {
@@ -6065,7 +6031,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_timex_loop_time_constant{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6082,7 +6048,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "description": "",
           "fieldConfig": {
@@ -6103,7 +6069,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_timex_sync_status{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6116,7 +6082,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_timex_frequency_adjustment_ratio{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6133,7 +6099,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "description": "",
           "fieldConfig": {
@@ -6154,7 +6120,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_timex_tick_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6167,7 +6133,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_timex_tai_offset_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6198,7 +6164,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -6219,7 +6185,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_procs_blocked{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6231,7 +6197,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_procs_running{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6247,7 +6213,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -6268,7 +6234,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_processes_state{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6285,7 +6251,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -6306,7 +6272,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_forks_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -6323,7 +6289,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -6343,7 +6309,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(process_virtual_memory_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "hide": false,
@@ -6356,7 +6322,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "process_resident_memory_max_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "hide": false,
@@ -6369,7 +6335,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(process_virtual_memory_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "hide": false,
@@ -6382,7 +6348,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(process_virtual_memory_max_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "hide": false,
@@ -6399,7 +6365,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -6420,7 +6386,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_processes_pids{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6433,7 +6399,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_processes_max_processes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6450,7 +6416,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -6471,7 +6437,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_schedstat_running_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -6484,7 +6450,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_schedstat_waiting_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -6501,7 +6467,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -6522,7 +6488,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_processes_threads{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6535,7 +6501,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_processes_max_threads{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6566,7 +6532,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -6587,7 +6553,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_context_switches_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -6599,7 +6565,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_intr_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -6616,7 +6582,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -6637,7 +6603,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_load1{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6649,7 +6615,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_load5{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6661,7 +6627,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_load15{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6677,7 +6643,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -6697,7 +6663,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_interrupts_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -6714,7 +6680,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -6735,7 +6701,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_schedstat_timeslices_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -6752,7 +6718,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -6773,7 +6739,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_entropy_available_bits{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6789,7 +6755,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -6810,7 +6776,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(process_cpu_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -6827,7 +6793,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -6847,7 +6813,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "process_max_fds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "interval": "",
@@ -6859,7 +6825,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "process_open_fds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "interval": "",
@@ -6889,7 +6855,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -6909,7 +6875,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_hwmon_temp_celsius{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6922,7 +6888,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_hwmon_temp_crit_alarm_celsius{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6936,7 +6902,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_hwmon_temp_crit_celsius{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6949,7 +6915,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_hwmon_temp_crit_hyst_celsius{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6963,7 +6929,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_hwmon_temp_max_celsius{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -6981,7 +6947,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -7001,7 +6967,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_cooling_device_cur_state{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -7015,7 +6981,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_cooling_device_max_state{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -7032,7 +6998,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -7052,7 +7018,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_power_supply_online{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -7084,7 +7050,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -7104,7 +7070,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_systemd_socket_accepted_connections_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -7121,7 +7087,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -7141,7 +7107,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_systemd_units{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",state=\"activating\"}",
               "format": "time_series",
@@ -7154,7 +7120,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_systemd_units{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",state=\"active\"}",
               "format": "time_series",
@@ -7167,7 +7133,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_systemd_units{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",state=\"deactivating\"}",
               "format": "time_series",
@@ -7180,7 +7146,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_systemd_units{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",state=\"failed\"}",
               "format": "time_series",
@@ -7193,7 +7159,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_systemd_units{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",state=\"inactive\"}",
               "format": "time_series",
@@ -7224,7 +7190,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "description": "The number (after merges) of I/O requests completed per second for the device",
           "fieldConfig": {
@@ -7250,7 +7216,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_disk_reads_completed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "intervalFactor": 1,
@@ -7261,7 +7227,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_disk_writes_completed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "intervalFactor": 1,
@@ -7276,7 +7242,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "description": "The number of bytes read from or written to the device per second",
           "fieldConfig": {
@@ -7302,7 +7268,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_disk_read_bytes_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -7314,7 +7280,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_disk_written_bytes_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -7330,7 +7296,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "description": "The average time for requests issued to the device to be served. This includes the time spent by the requests in queue and the time spent servicing them.",
           "fieldConfig": {
@@ -7356,7 +7322,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_disk_read_time_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval]) / rate(node_disk_reads_completed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "hide": false,
@@ -7369,7 +7335,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_disk_write_time_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval]) / rate(node_disk_writes_completed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "hide": false,
@@ -7386,7 +7352,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "description": "The average queue length of the requests that were issued to the device",
           "fieldConfig": {
@@ -7412,7 +7378,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_disk_io_time_weighted_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "interval": "",
@@ -7428,7 +7394,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "description": "The number of read and write requests merged per second that were queued to the device",
           "fieldConfig": {
@@ -7454,7 +7420,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_disk_reads_merged_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "intervalFactor": 1,
@@ -7465,7 +7431,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_disk_writes_merged_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "intervalFactor": 1,
@@ -7480,7 +7446,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "description": "Percentage of elapsed time during which I/O requests were issued to the device (bandwidth utilization for the device). Device saturation occurs when this value is close to 100% for devices serving requests serially.  But for devices  serving requests in parallel, such as RAID arrays and modern SSDs, this number does not reflect their performance limits.",
           "fieldConfig": {
@@ -7506,7 +7472,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_disk_io_time_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "interval": "",
@@ -7518,7 +7484,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_disk_discard_time_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "interval": "",
@@ -7534,7 +7500,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "description": "The number of outstanding requests at the instant the sample was taken. Incremented as requests are given to appropriate struct request_queue and decremented as they finish.",
           "fieldConfig": {
@@ -7560,7 +7526,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_disk_io_now{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"})",
               "interval": "",
@@ -7576,7 +7542,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "description": "",
           "fieldConfig": {
@@ -7602,7 +7568,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_disk_discards_completed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "interval": "",
@@ -7614,7 +7580,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_disk_discards_merged_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "interval": "",
@@ -7644,7 +7610,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "description": "",
           "fieldConfig": {
@@ -7670,7 +7636,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_filesystem_avail_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'}",
               "format": "time_series",
@@ -7684,7 +7650,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_filesystem_free_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'}",
               "format": "time_series",
@@ -7697,7 +7663,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_filesystem_size_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'}",
               "format": "time_series",
@@ -7714,7 +7680,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "description": "",
           "fieldConfig": {
@@ -7739,7 +7705,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_filesystem_files_free{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'}",
               "format": "time_series",
@@ -7756,7 +7722,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "description": "",
           "fieldConfig": {
@@ -7782,7 +7748,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_filefd_maximum{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -7794,7 +7760,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_filefd_allocated{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -7810,7 +7776,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "description": "",
           "fieldConfig": {
@@ -7835,7 +7801,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_filesystem_files{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'}",
               "format": "time_series",
@@ -7852,7 +7818,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "description": "",
           "fieldConfig": {
@@ -7878,7 +7844,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_filesystem_readonly{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'}",
               "format": "time_series",
@@ -7890,7 +7856,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_filesystem_device_error{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs',fstype!~'tmpfs'}",
               "format": "time_series",
@@ -7921,7 +7887,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -7941,7 +7907,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_network_receive_packets_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -7954,7 +7920,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_network_transmit_packets_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -7971,7 +7937,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -7991,7 +7957,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_network_receive_errs_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -8003,7 +7969,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_network_transmit_errs_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -8019,7 +7985,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -8039,7 +8005,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_network_receive_drop_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -8051,7 +8017,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_network_transmit_drop_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -8067,7 +8033,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -8087,7 +8053,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_network_receive_compressed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -8099,7 +8065,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_network_transmit_compressed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -8115,7 +8081,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -8135,7 +8101,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_network_receive_multicast_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -8151,7 +8117,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -8171,7 +8137,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_network_receive_fifo_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -8183,7 +8149,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_network_transmit_fifo_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -8199,7 +8165,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -8219,7 +8185,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_network_receive_frame_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -8236,7 +8202,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -8256,7 +8222,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_network_transmit_carrier_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -8272,7 +8238,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -8292,7 +8258,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_network_transmit_colls_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -8308,7 +8274,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -8328,7 +8294,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_nf_conntrack_entries{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8340,7 +8306,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_nf_conntrack_entries_limit{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8356,7 +8322,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -8376,7 +8342,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_arp_entries{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8392,7 +8358,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -8412,7 +8378,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_network_mtu_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8428,7 +8394,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -8448,7 +8414,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_network_speed_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8464,7 +8430,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -8484,7 +8450,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_network_transmit_queue_length{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8500,7 +8466,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -8520,7 +8486,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_softnet_processed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -8533,7 +8499,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_softnet_dropped_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -8550,7 +8516,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -8570,7 +8536,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_softnet_times_squeezed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -8587,7 +8553,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {},
@@ -8607,7 +8573,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_network_up{operstate=\"up\",supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8619,7 +8585,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_network_carrier{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8648,7 +8614,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -8672,7 +8638,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_sockstat_TCP_alloc{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8685,7 +8651,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_sockstat_TCP_inuse{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8698,7 +8664,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_sockstat_TCP_mem{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8712,7 +8678,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_sockstat_TCP_orphan{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8725,7 +8691,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_sockstat_TCP_tw{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8742,7 +8708,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -8766,7 +8732,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_sockstat_UDPLITE_inuse{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8779,7 +8745,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_sockstat_UDP_inuse{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8792,7 +8758,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_sockstat_UDP_mem{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8809,7 +8775,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -8833,7 +8799,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_sockstat_FRAG_inuse{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8846,7 +8812,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_sockstat_RAW_inuse{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8863,7 +8829,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -8887,7 +8853,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_sockstat_TCP_mem_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8900,7 +8866,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_sockstat_UDP_mem_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8913,7 +8879,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_sockstat_FRAG_memory{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "interval": "",
@@ -8928,7 +8894,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -8952,7 +8918,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_sockstat_sockets_used{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -8983,7 +8949,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -9008,7 +8974,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_netstat_IpExt_InOctets{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9021,7 +8987,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_netstat_IpExt_OutOctets{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9037,7 +9003,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -9061,7 +9027,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_netstat_Ip_Forwarding{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9078,7 +9044,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -9103,7 +9069,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_netstat_Icmp_InMsgs{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9116,7 +9082,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_netstat_Icmp_OutMsgs{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9133,7 +9099,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -9158,7 +9124,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_netstat_Icmp_InErrors{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9175,7 +9141,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -9200,7 +9166,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_netstat_Udp_InDatagrams{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9213,7 +9179,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_netstat_Udp_OutDatagrams{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9230,7 +9196,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -9255,7 +9221,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_netstat_Udp_InErrors{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9268,7 +9234,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_netstat_Udp_NoPorts{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9281,7 +9247,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_netstat_UdpLite_InErrors{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "interval": "",
@@ -9291,7 +9257,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_netstat_Udp_RcvbufErrors{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9304,7 +9270,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_netstat_Udp_SndbufErrors{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9321,7 +9287,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -9346,7 +9312,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_netstat_Tcp_InSegs{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9360,7 +9326,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_netstat_Tcp_OutSegs{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9377,7 +9343,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "description": "",
           "fieldConfig": {
@@ -9403,7 +9369,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_netstat_TcpExt_ListenOverflows{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9417,7 +9383,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_netstat_TcpExt_ListenDrops{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9431,7 +9397,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_netstat_TcpExt_TCPSynRetrans{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9444,7 +9410,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_netstat_Tcp_RetransSegs{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "interval": "",
@@ -9454,7 +9420,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_netstat_Tcp_InErrs{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "interval": "",
@@ -9464,7 +9430,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_netstat_Tcp_OutRsts{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "interval": "",
@@ -9478,7 +9444,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -9503,7 +9469,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_netstat_Tcp_CurrEstab{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -9517,7 +9483,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_netstat_Tcp_MaxConn{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -9535,7 +9501,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "description": "",
           "fieldConfig": {
@@ -9561,7 +9527,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_netstat_TcpExt_SyncookiesFailed{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9575,7 +9541,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_netstat_TcpExt_SyncookiesRecv{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9589,7 +9555,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_netstat_TcpExt_SyncookiesSent{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9607,7 +9573,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -9632,7 +9598,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_netstat_Tcp_ActiveOpens{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9645,7 +9611,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "rate(node_netstat_Tcp_PassiveOpens{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
@@ -9676,7 +9642,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "description": "",
           "fieldConfig": {
@@ -9697,7 +9663,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_scrape_collector_duration_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -9715,7 +9681,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "grafanacloud-prom"
+            "uid": "prometheus"
           },
           "description": "",
           "fieldConfig": {
@@ -9736,7 +9702,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_scrape_collector_success{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -9750,7 +9716,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "grafanacloud-prom"
+                "uid": "prometheus"
               },
               "expr": "node_textfile_scrape_error{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
@@ -9783,7 +9749,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "grafanacloud-prom"
+          "uid": "prometheus"
         },
         "definition": "label_values(supabase_project_ref)",
         "includeAll": false,
@@ -9824,7 +9790,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "grafanacloud-prom"
+          "uid": "prometheus"
         },
         "definition": "label_values(supabase_identifier)",
         "includeAll": false,

--- a/grafana/dashboard.json
+++ b/grafana/dashboard.json
@@ -18,16 +18,11 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 29,
+  "id": 25,
   "links": [],
-  "liveNow": false,
   "panels": [
     {
       "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -42,7 +37,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "grafanacloud-prom"
       },
       "description": "Busy state of all CPU cores together",
       "fieldConfig": {
@@ -67,7 +62,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "rgba(50, 172, 45, 0.97)"
+                "color": "rgba(50, 172, 45, 0.97)",
+                "value": 0
               },
               {
                 "color": "rgba(237, 129, 40, 0.89)",
@@ -90,8 +86,9 @@
         "y": 1
       },
       "id": 20,
-      "links": [],
       "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
@@ -101,12 +98,17 @@
           "values": false
         },
         "showThresholdLabels": false,
-        "showThresholdMarkers": true
+        "showThresholdMarkers": true,
+        "sizing": "auto"
       },
-      "pluginVersion": "8.3.3",
+      "pluginVersion": "12.1.0-88993",
       "targets": [
         {
-          "expr": "clamp_min(100 - (avg(rate(node_cpu_seconds_total{mode=\"idle\", supabase_project_ref=\"$project\"}[$__rate_interval])) by (instance) * 100), 0)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "clamp_min(100 - (avg(rate(node_cpu_seconds_total{mode=\"idle\", supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) by (instance) * 100), 0)",
           "hide": false,
           "intervalFactor": 1,
           "legendFormat": "",
@@ -120,7 +122,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "grafanacloud-prom"
       },
       "description": "Busy state of all CPU cores together (5 min average)",
       "fieldConfig": {
@@ -145,7 +147,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "rgba(50, 172, 45, 0.97)"
+                "color": "rgba(50, 172, 45, 0.97)",
+                "value": 0
               },
               {
                 "color": "rgba(237, 129, 40, 0.89)",
@@ -168,8 +171,9 @@
         "y": 1
       },
       "id": 155,
-      "links": [],
       "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
@@ -179,12 +183,17 @@
           "values": false
         },
         "showThresholdLabels": false,
-        "showThresholdMarkers": true
+        "showThresholdMarkers": true,
+        "sizing": "auto"
       },
-      "pluginVersion": "8.3.3",
+      "pluginVersion": "12.1.0-88993",
       "targets": [
         {
-          "expr": "avg(node_load5{supabase_project_ref=\"$project\"}) /  count(count(node_cpu_seconds_total{supabase_project_ref=\"$project\"}) by (cpu)) * 100",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "avg(node_load5{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}) /  count(count(node_cpu_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}) by (cpu)) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -198,7 +207,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "grafanacloud-prom"
       },
       "description": "Busy state of all CPU cores together (15 min average)",
       "fieldConfig": {
@@ -223,7 +232,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "rgba(50, 172, 45, 0.97)"
+                "color": "rgba(50, 172, 45, 0.97)",
+                "value": 0
               },
               {
                 "color": "rgba(237, 129, 40, 0.89)",
@@ -246,8 +256,9 @@
         "y": 1
       },
       "id": 19,
-      "links": [],
       "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
@@ -257,12 +268,17 @@
           "values": false
         },
         "showThresholdLabels": false,
-        "showThresholdMarkers": true
+        "showThresholdMarkers": true,
+        "sizing": "auto"
       },
-      "pluginVersion": "8.3.3",
+      "pluginVersion": "12.1.0-88993",
       "targets": [
         {
-          "expr": "avg(node_load15{supabase_project_ref=\"$project\"}) /  count(count(node_cpu_seconds_total{supabase_project_ref=\"$project\"}) by (cpu)) * 100",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "avg(node_load15{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}) /  count(count(node_cpu_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}) by (cpu)) * 100",
           "hide": false,
           "intervalFactor": 1,
           "refId": "A",
@@ -275,7 +291,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "grafanacloud-prom"
       },
       "description": "Non available RAM memory",
       "fieldConfig": {
@@ -291,7 +307,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "rgba(50, 172, 45, 0.97)"
+                "color": "rgba(50, 172, 45, 0.97)",
+                "value": 0
               },
               {
                 "color": "rgba(237, 129, 40, 0.89)",
@@ -313,10 +330,10 @@
         "x": 9,
         "y": 1
       },
-      "hideTimeOverride": false,
       "id": 16,
-      "links": [],
       "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
@@ -326,12 +343,17 @@
           "values": false
         },
         "showThresholdLabels": false,
-        "showThresholdMarkers": true
+        "showThresholdMarkers": true,
+        "sizing": "auto"
       },
-      "pluginVersion": "8.3.3",
+      "pluginVersion": "12.1.0-88993",
       "targets": [
         {
-          "expr": "((node_memory_MemTotal_bytes{supabase_project_ref=\"$project\"} - node_memory_MemFree_bytes{supabase_project_ref=\"$project\"}) / (node_memory_MemTotal_bytes{supabase_project_ref=\"$project\"} )) * 100",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "((node_memory_MemTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_MemFree_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}) / (node_memory_MemTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} )) * 100",
           "format": "time_series",
           "hide": true,
           "intervalFactor": 1,
@@ -339,7 +361,11 @@
           "step": 240
         },
         {
-          "expr": "100 - ((node_memory_MemAvailable_bytes{supabase_project_ref=\"$project\"} * 100) / node_memory_MemTotal_bytes{supabase_project_ref=\"$project\"})",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "100 - ((node_memory_MemAvailable_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} * 100) / node_memory_MemTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -353,7 +379,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "grafanacloud-prom"
       },
       "description": "Used Swap",
       "fieldConfig": {
@@ -378,7 +404,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "rgba(50, 172, 45, 0.97)"
+                "color": "rgba(50, 172, 45, 0.97)",
+                "value": 0
               },
               {
                 "color": "rgba(237, 129, 40, 0.89)",
@@ -401,8 +428,9 @@
         "y": 1
       },
       "id": 21,
-      "links": [],
       "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
@@ -412,12 +440,17 @@
           "values": false
         },
         "showThresholdLabels": false,
-        "showThresholdMarkers": true
+        "showThresholdMarkers": true,
+        "sizing": "auto"
       },
-      "pluginVersion": "8.3.3",
+      "pluginVersion": "12.1.0-88993",
       "targets": [
         {
-          "expr": "((node_memory_SwapTotal_bytes{supabase_project_ref=\"$project\"} - node_memory_SwapFree_bytes{supabase_project_ref=\"$project\"}) / (node_memory_SwapTotal_bytes{supabase_project_ref=\"$project\"} )) * 100",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "((node_memory_SwapTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_SwapFree_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}) / (node_memory_SwapTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} )) * 100",
           "intervalFactor": 1,
           "refId": "A",
           "step": 240
@@ -429,7 +462,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "grafanacloud-prom"
       },
       "description": "Used Root FS",
       "fieldConfig": {
@@ -454,7 +487,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "rgba(50, 172, 45, 0.97)"
+                "color": "rgba(50, 172, 45, 0.97)",
+                "value": 0
               },
               {
                 "color": "rgba(237, 129, 40, 0.89)",
@@ -477,8 +511,9 @@
         "y": 1
       },
       "id": 154,
-      "links": [],
       "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
@@ -488,12 +523,17 @@
           "values": false
         },
         "showThresholdLabels": false,
-        "showThresholdMarkers": true
+        "showThresholdMarkers": true,
+        "sizing": "auto"
       },
-      "pluginVersion": "8.3.3",
+      "pluginVersion": "12.1.0-88993",
       "targets": [
         {
-          "expr": "100 - ((node_filesystem_avail_bytes{supabase_project_ref=\"$project\",mountpoint=\"/\",fstype!=\"rootfs\"} * 100) / node_filesystem_size_bytes{supabase_project_ref=\"$project\",mountpoint=\"/\",fstype!=\"rootfs\"})",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "100 - ((node_filesystem_avail_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",mountpoint=\"/\",fstype!=\"rootfs\"} * 100) / node_filesystem_size_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",mountpoint=\"/\",fstype!=\"rootfs\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A",
@@ -506,7 +546,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "grafanacloud-prom"
       },
       "description": "Total number of CPU cores",
       "fieldConfig": {
@@ -529,7 +569,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -548,13 +589,13 @@
         "y": 1
       },
       "id": 14,
-      "links": [],
       "maxDataPoints": 100,
       "options": {
         "colorMode": "none",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -562,12 +603,18 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.3.3",
+      "pluginVersion": "12.1.0-88993",
       "targets": [
         {
-          "expr": "count(count(node_cpu_seconds_total{supabase_project_ref=\"$project\"}) by (cpu))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "count(count(node_cpu_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}) by (cpu))",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "",
@@ -581,7 +628,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "grafanacloud-prom"
       },
       "description": "System uptime",
       "fieldConfig": {
@@ -605,7 +652,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -623,15 +671,14 @@
         "x": 20,
         "y": 1
       },
-      "hideTimeOverride": true,
       "id": 15,
-      "links": [],
       "maxDataPoints": 100,
       "options": {
         "colorMode": "none",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -639,17 +686,19 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.3.3",
+      "pluginVersion": "12.1.0-88993",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "node_time_seconds{supabase_project_ref=\"$project\"} - node_boot_time_seconds{supabase_project_ref=\"$project\"}",
+          "expr": "node_time_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_boot_time_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "",
@@ -663,7 +712,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "grafanacloud-prom"
       },
       "description": "Total SWAP",
       "fieldConfig": {
@@ -687,7 +736,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -706,13 +756,13 @@
         "y": 1
       },
       "id": 18,
-      "links": [],
       "maxDataPoints": 100,
       "options": {
         "colorMode": "none",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -720,12 +770,18 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.3.3",
+      "pluginVersion": "12.1.0-88993",
       "targets": [
         {
-          "expr": "node_memory_SwapTotal_bytes{supabase_project_ref=\"$project\"}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "node_memory_SwapTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
           "intervalFactor": 1,
           "refId": "A",
           "step": 240
@@ -737,7 +793,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "grafanacloud-prom"
       },
       "description": "Total RootFS",
       "fieldConfig": {
@@ -761,7 +817,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "rgba(50, 172, 45, 0.97)"
+                "color": "rgba(50, 172, 45, 0.97)",
+                "value": 0
               },
               {
                 "color": "rgba(237, 129, 40, 0.89)",
@@ -784,13 +841,13 @@
         "y": 3
       },
       "id": 23,
-      "links": [],
       "maxDataPoints": 100,
       "options": {
         "colorMode": "none",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -798,17 +855,19 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.3.3",
+      "pluginVersion": "12.1.0-88993",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "node_filesystem_size_bytes{supabase_project_ref=\"$project\",mountpoint=\"/\",fstype!=\"rootfs\"}",
+          "expr": "node_filesystem_size_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",mountpoint=\"/\",fstype!=\"rootfs\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -824,7 +883,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "grafanacloud-prom"
       },
       "description": "Total data disk capacity",
       "fieldConfig": {
@@ -848,7 +907,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "rgba(50, 172, 45, 0.97)"
+                "color": "rgba(50, 172, 45, 0.97)",
+                "value": 0
               },
               {
                 "color": "rgba(237, 129, 40, 0.89)",
@@ -871,13 +931,13 @@
         "y": 3
       },
       "id": 322,
-      "links": [],
       "maxDataPoints": 100,
       "options": {
         "colorMode": "none",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -885,17 +945,19 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.3.3",
+      "pluginVersion": "12.1.0-88993",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "node_filesystem_size_bytes{supabase_project_ref=\"$project\",mountpoint=\"/data\",fstype!=\"rootfs\"}",
+          "expr": "node_filesystem_size_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",mountpoint=\"/data\",fstype!=\"rootfs\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -912,7 +974,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "grafanacloud-prom"
       },
       "description": "Total RAM",
       "fieldConfig": {
@@ -936,7 +998,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -955,13 +1018,13 @@
         "y": 3
       },
       "id": 75,
-      "links": [],
       "maxDataPoints": 100,
       "options": {
         "colorMode": "none",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -969,12 +1032,18 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.3.3",
+      "pluginVersion": "12.1.0-88993",
       "targets": [
         {
-          "expr": "node_memory_MemTotal_bytes{supabase_project_ref=\"$project\"}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "node_memory_MemTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
           "intervalFactor": 1,
           "refId": "A",
           "step": 240
@@ -985,10 +1054,6 @@
     },
     {
       "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1001,507 +1066,24 @@
       "type": "row"
     },
     {
-      "aliasColors": {
-        "Busy": "#EAB839",
-        "Busy Iowait": "#890F02",
-        "Busy other": "#1F78C1",
-        "Idle": "#052B51",
-        "Idle - Waiting for something to happen": "#052B51",
-        "guest": "#9AC48A",
-        "idle": "#052B51",
-        "iowait": "#EAB839",
-        "irq": "#BF1B00",
-        "nice": "#C15C17",
-        "softirq": "#E24D42",
-        "steal": "#FCE2DE",
-        "system": "#508642",
-        "user": "#5195CE"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "grafanacloud-prom"
       },
-      "decimals": 2,
       "description": "Basic CPU info",
-      "fieldConfig": {
-        "defaults": {
-          "links": []
-        },
-        "overrides": []
-      },
-      "fill": 4,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 0,
-        "y": 6
-      },
-      "hiddenSeries": false,
-      "id": 77,
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "sideWidth": 250,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "maxPerRow": 6,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": true,
-      "pluginVersion": "8.3.3",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "alias": "Busy Iowait",
-          "color": "#890F02"
-        },
-        {
-          "alias": "Idle",
-          "color": "#7EB26D"
-        },
-        {
-          "alias": "Busy System",
-          "color": "#EAB839"
-        },
-        {
-          "alias": "Busy User",
-          "color": "#0A437C"
-        },
-        {
-          "alias": "Busy Other",
-          "color": "#6D1F62"
-        }
-      ],
-      "spaceLength": 10,
-      "stack": true,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode=\"system\",supabase_project_ref=\"$project\"}[$__rate_interval])) * 100",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 1,
-          "legendFormat": "Busy System",
-          "refId": "A",
-          "step": 240
-        },
-        {
-          "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode='user',supabase_project_ref=\"$project\"}[$__rate_interval])) * 100",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 1,
-          "legendFormat": "Busy User",
-          "refId": "B",
-          "step": 240
-        },
-        {
-          "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode='iowait',supabase_project_ref=\"$project\"}[$__rate_interval])) * 100",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Busy Iowait",
-          "refId": "C",
-          "step": 240
-        },
-        {
-          "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode=~\".*irq\",supabase_project_ref=\"$project\"}[$__rate_interval])) * 100",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Busy IRQs",
-          "refId": "D",
-          "step": 240
-        },
-        {
-          "expr": "sum (rate(node_cpu_seconds_total{mode!='idle',mode!='user',mode!='system',mode!='iowait',mode!='irq',mode!='softirq',supabase_project_ref=\"$project\"}[$__rate_interval])) * 100",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Busy Other",
-          "refId": "E",
-          "step": 240
-        },
-        {
-          "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='idle',supabase_project_ref=\"$project\"}[$__rate_interval])) * 100",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Idle",
-          "refId": "F",
-          "step": 240
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "CPU Basic",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:123",
-          "format": "short",
-          "label": "",
-          "logBase": 1,
-          "max": "100",
-          "min": "0",
-          "show": true
-        },
-        {
-          "$$hashKey": "object:124",
-          "format": "short",
-          "logBase": 1,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "aliasColors": {
-        "Apps": "#629E51",
-        "Buffers": "#614D93",
-        "Cache": "#6D1F62",
-        "Cached": "#511749",
-        "Committed": "#508642",
-        "Free": "#0A437C",
-        "Hardware Corrupted - Amount of RAM that the kernel identified as corrupted / not working": "#CFFAFF",
-        "Inactive": "#584477",
-        "PageTables": "#0A50A1",
-        "Page_Tables": "#0A50A1",
-        "RAM_Free": "#E0F9D7",
-        "SWAP Used": "#BF1B00",
-        "Slab": "#806EB7",
-        "Slab_Cache": "#E0752D",
-        "Swap": "#BF1B00",
-        "Swap Used": "#BF1B00",
-        "Swap_Cache": "#C15C17",
-        "Swap_Free": "#2F575E",
-        "Unused": "#EAB839"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "decimals": 2,
-      "description": "Basic memory usage",
-      "fieldConfig": {
-        "defaults": {
-          "links": []
-        },
-        "overrides": []
-      },
-      "fill": 4,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 12,
-        "y": 6
-      },
-      "hiddenSeries": false,
-      "id": 78,
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "sideWidth": 350,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "maxPerRow": 6,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "8.3.3",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "alias": "RAM Total",
-          "color": "#E0F9D7",
-          "fill": 0,
-          "stack": false
-        },
-        {
-          "alias": "RAM Cache + Buffer",
-          "color": "#052B51"
-        },
-        {
-          "alias": "RAM Free",
-          "color": "#7EB26D"
-        },
-        {
-          "alias": "Avaliable",
-          "color": "#DEDAF7",
-          "fill": 0,
-          "stack": false
-        }
-      ],
-      "spaceLength": 10,
-      "stack": true,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "node_memory_MemTotal_bytes{supabase_project_ref=\"$project\"}",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 1,
-          "legendFormat": "RAM Total",
-          "refId": "A",
-          "step": 240
-        },
-        {
-          "expr": "node_memory_MemTotal_bytes{supabase_project_ref=\"$project\"} - node_memory_MemFree_bytes{supabase_project_ref=\"$project\"} - (node_memory_Cached_bytes{supabase_project_ref=\"$project\"} + node_memory_Buffers_bytes{supabase_project_ref=\"$project\"})",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 1,
-          "legendFormat": "RAM Used",
-          "refId": "B",
-          "step": 240
-        },
-        {
-          "expr": "node_memory_Cached_bytes{supabase_project_ref=\"$project\"} + node_memory_Buffers_bytes{supabase_project_ref=\"$project\"}",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "RAM Cache + Buffer",
-          "refId": "C",
-          "step": 240
-        },
-        {
-          "expr": "node_memory_MemFree_bytes{supabase_project_ref=\"$project\"}",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "RAM Free",
-          "refId": "D",
-          "step": 240
-        },
-        {
-          "expr": "(node_memory_SwapTotal_bytes{supabase_project_ref=\"$project\"} - node_memory_SwapFree_bytes{supabase_project_ref=\"$project\"})",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "SWAP Used",
-          "refId": "E",
-          "step": 240
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Memory Basic",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "bytes",
-          "label": "",
-          "logBase": 1,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "aliasColors": {
-        "Recv_bytes_eth2": "#7EB26D",
-        "Recv_bytes_lo": "#0A50A1",
-        "Recv_drop_eth2": "#6ED0E0",
-        "Recv_drop_lo": "#E0F9D7",
-        "Recv_errs_eth2": "#BF1B00",
-        "Recv_errs_lo": "#CCA300",
-        "Trans_bytes_eth2": "#7EB26D",
-        "Trans_bytes_lo": "#0A50A1",
-        "Trans_drop_eth2": "#6ED0E0",
-        "Trans_drop_lo": "#E0F9D7",
-        "Trans_errs_eth2": "#BF1B00",
-        "Trans_errs_lo": "#CCA300",
-        "recv_bytes_lo": "#0A50A1",
-        "recv_drop_eth0": "#99440A",
-        "recv_drop_lo": "#967302",
-        "recv_errs_eth0": "#BF1B00",
-        "recv_errs_lo": "#890F02",
-        "trans_bytes_eth0": "#7EB26D",
-        "trans_bytes_lo": "#0A50A1",
-        "trans_drop_eth0": "#99440A",
-        "trans_drop_lo": "#967302",
-        "trans_errs_eth0": "#BF1B00",
-        "trans_errs_lo": "#890F02"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "description": "Basic network info per interface",
-      "fieldConfig": {
-        "defaults": {
-          "links": []
-        },
-        "overrides": []
-      },
-      "fill": 4,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 0,
-        "y": 13
-      },
-      "hiddenSeries": false,
-      "id": 74,
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "hideEmpty": false,
-        "hideZero": false,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "sort": "current",
-        "sortDesc": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "8.3.3",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "alias": "/.*trans.*/",
-          "transform": "negative-Y"
-        }
-      ],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "rate(node_network_receive_bytes_total{supabase_project_ref=\"$project\"}[$__rate_interval])*8",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "recv {{device}}",
-          "refId": "A",
-          "step": 240
-        },
-        {
-          "expr": "rate(node_network_transmit_bytes_total{supabase_project_ref=\"$project\"}[$__rate_interval])*8",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "trans {{device}} ",
-          "refId": "B",
-          "step": 240
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Network Traffic Basic",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "bps",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "format": "pps",
-          "label": "",
-          "logBase": 1,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "description": "Disk space used of all filesystems mounted",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 40,
             "gradientMode": "none",
@@ -1510,6 +1092,1454 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "percent"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Busy"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#EAB839",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Busy Iowait"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#890F02",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Busy other"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#1F78C1",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Idle"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#052B51",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Idle - Waiting for something to happen"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#052B51",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "guest"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#9AC48A",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "idle"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#052B51",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "iowait"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#EAB839",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "irq"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#BF1B00",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "nice"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#C15C17",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "softirq"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#E24D42",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "steal"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FCE2DE",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "system"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#508642",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "user"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#5195CE",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Busy Iowait"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#890F02",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Idle"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#7EB26D",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Busy System"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#EAB839",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Busy User"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#0A437C",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Busy Other"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#6D1F62",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 77,
+      "maxPerRow": 6,
+      "options": {
+        "alertThreshold": true,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "width": 250
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0-88993",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode=\"system\",supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "Busy System",
+          "refId": "A",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode='user',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "Busy User",
+          "refId": "B",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode='iowait',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Busy Iowait",
+          "refId": "C",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode=~\".*irq\",supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Busy IRQs",
+          "refId": "D",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "sum (rate(node_cpu_seconds_total{mode!='idle',mode!='user',mode!='system',mode!='iowait',mode!='irq',mode!='softirq',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Busy Other",
+          "refId": "E",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='idle',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Idle",
+          "refId": "F",
+          "step": 240
+        }
+      ],
+      "title": "CPU Basic",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "description": "Basic memory usage",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Apps"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#629E51",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Buffers"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#614D93",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Cache"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#6D1F62",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Cached"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#511749",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Committed"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#508642",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Free"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#0A437C",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Hardware Corrupted - Amount of RAM that the kernel identified as corrupted / not working"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#CFFAFF",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Inactive"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#584477",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PageTables"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#0A50A1",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Page_Tables"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#0A50A1",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RAM_Free"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#E0F9D7",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SWAP Used"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#BF1B00",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Slab"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#806EB7",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Slab_Cache"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#E0752D",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Swap"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#BF1B00",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Swap Used"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#BF1B00",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Swap_Cache"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#C15C17",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Swap_Free"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#2F575E",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Unused"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#EAB839",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RAM Total"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#E0F9D7",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RAM Cache + Buffer"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#052B51",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RAM Free"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#7EB26D",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Avaliable"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#DEDAF7",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 78,
+      "maxPerRow": 6,
+      "options": {
+        "alertThreshold": true,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "width": 350
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0-88993",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "node_memory_MemTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "RAM Total",
+          "refId": "A",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "node_memory_MemTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_MemFree_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - (node_memory_Cached_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} + node_memory_Buffers_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"})",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "RAM Used",
+          "refId": "B",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "node_memory_Cached_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} + node_memory_Buffers_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "RAM Cache + Buffer",
+          "refId": "C",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "node_memory_MemFree_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "RAM Free",
+          "refId": "D",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "(node_memory_SwapTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_SwapFree_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "SWAP Used",
+          "refId": "E",
+          "step": 240
+        }
+      ],
+      "title": "Memory Basic",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "description": "Basic network info per interface",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Recv_bytes_eth2"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#7EB26D",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Recv_bytes_lo"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#0A50A1",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Recv_drop_eth2"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#6ED0E0",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Recv_drop_lo"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#E0F9D7",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Recv_errs_eth2"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#BF1B00",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Recv_errs_lo"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#CCA300",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Trans_bytes_eth2"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#7EB26D",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Trans_bytes_lo"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#0A50A1",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Trans_drop_eth2"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#6ED0E0",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Trans_drop_lo"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#E0F9D7",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Trans_errs_eth2"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#BF1B00",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Trans_errs_lo"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#CCA300",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "recv_bytes_lo"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#0A50A1",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "recv_drop_eth0"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#99440A",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "recv_drop_lo"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#967302",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "recv_errs_eth0"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#BF1B00",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "recv_errs_lo"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#890F02",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "trans_bytes_eth0"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#7EB26D",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "trans_bytes_lo"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#0A50A1",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "trans_drop_eth0"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#99440A",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "trans_drop_lo"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#967302",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "trans_errs_eth0"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#BF1B00",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "trans_errs_lo"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#890F02",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*trans.*/"
+            },
+            "properties": [
+              {
+                "id": "custom.transform",
+                "value": "negative-Y"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 13
+      },
+      "id": 74,
+      "options": {
+        "alertThreshold": true,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0-88993",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "rate(node_network_receive_bytes_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])*8",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "recv {{device}}",
+          "refId": "A",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "rate(node_network_transmit_bytes_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])*8",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "trans {{device}} ",
+          "refId": "B",
+          "step": 240
+        }
+      ],
+      "title": "Network Traffic Basic",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "description": "Disk space used of all filesystems mounted",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -1534,7 +2564,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -1566,21 +2597,27 @@
         "y": 13
       },
       "id": 152,
-      "links": [],
       "options": {
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "multi"
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
         }
       },
-      "pluginVersion": "8.3.3",
+      "pluginVersion": "12.1.0-88993",
       "targets": [
         {
-          "expr": "100 - ((node_filesystem_avail_bytes{supabase_project_ref=\"$project\",device!~'rootfs'} * 100) / node_filesystem_size_bytes{supabase_project_ref=\"$project\",device!~'rootfs'})",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "expr": "100 - ((node_filesystem_avail_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'} * 100) / node_filesystem_size_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Disk mounted at {{mountpoint}}",
@@ -1607,7 +2644,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "grafanacloud-prom"
       },
       "description": "Disk space used by the database",
       "fieldConfig": {
@@ -1616,10 +2653,14 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "axisSoftMax": 100,
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 40,
             "gradientMode": "none",
@@ -1628,6 +2669,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -1651,7 +2693,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               }
             ]
           },
@@ -1666,26 +2709,28 @@
         "y": 21
       },
       "id": 321,
-      "links": [],
       "options": {
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
         }
       },
-      "pluginVersion": "8.3.3",
+      "pluginVersion": "12.1.0-88993",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "pg_database_size_mb{supabase_project_ref=\"$project\"}",
+          "expr": "pg_database_size_mb{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1700,7 +2745,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "grafanacloud-prom"
       },
       "description": "Active number of client connections",
       "fieldConfig": {
@@ -1709,10 +2754,14 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "axisSoftMax": 20,
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -1721,6 +2770,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -1744,7 +2794,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               }
             ]
           },
@@ -1772,26 +2823,28 @@
         "y": 21
       },
       "id": 323,
-      "links": [],
       "options": {
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "multi"
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
         }
       },
-      "pluginVersion": "8.3.3",
+      "pluginVersion": "12.1.0-88993",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "pg_stat_database_num_backends{supabase_project_ref=\"$project\"}",
+          "expr": "pg_stat_database_num_backends{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1802,10 +2855,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "sum(supavisor_connections_active{supabase_project_ref=\"$project\"})",
+          "expr": "sum(supavisor_connections_active{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1816,10 +2869,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "pgbouncer_used_clients{supabase_project_ref=\"$project\"}",
+          "expr": "pgbouncer_used_clients{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1831,10 +2884,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "sum by (Name) (pgbouncer_pools_client_waiting_connections{supabase_project_ref=\"$project\"})",
+          "expr": "sum by (Name) (pgbouncer_pools_client_waiting_connections{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1850,7 +2903,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "grafanacloud-prom"
       },
       "fieldConfig": {
         "defaults": {
@@ -1878,7 +2931,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -1905,6 +2959,7 @@
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -1912,18 +2967,20 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.3.3",
+      "pluginVersion": "12.1.0-88993",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "pg_up{supabase_project_ref=\"$project\"}",
+          "expr": "pg_up{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -1935,7 +2992,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "grafanacloud-prom"
       },
       "fieldConfig": {
         "defaults": {
@@ -1963,7 +3020,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -1990,6 +3048,7 @@
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -1997,18 +3056,20 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.3.3",
+      "pluginVersion": "12.1.0-88993",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "pgbouncer_up{supabase_project_ref=\"$project\"}",
+          "expr": "pgbouncer_up{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -2020,7 +3081,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "grafanacloud-prom"
       },
       "description": "",
       "fieldConfig": {
@@ -2029,10 +3090,14 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "axisSoftMax": 5,
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -2041,6 +3106,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -2064,7 +3130,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               }
             ]
           },
@@ -2099,26 +3166,28 @@
         "y": 27
       },
       "id": 330,
-      "links": [],
       "options": {
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "multi"
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
         }
       },
-      "pluginVersion": "8.3.3",
+      "pluginVersion": "12.1.0-88993",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "rate(supabase_usage_metrics_user_queries_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+          "expr": "rate(supabase_usage_metrics_user_queries_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -2129,10 +3198,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "rate(pg_stat_statements_total_queries{supabase_project_ref=\"$project\"}[$__rate_interval])",
+          "expr": "rate(pg_stat_statements_total_queries{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
           "hide": false,
           "interval": "",
           "legendFormat": "Total no. of queries",
@@ -2141,10 +3210,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "rate(pg_stat_statements_total_time_seconds{supabase_project_ref=\"$project\"}[$__rate_interval])",
+          "expr": "rate(pg_stat_statements_total_time_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -2158,7 +3227,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "grafanacloud-prom"
       },
       "description": "",
       "fieldConfig": {
@@ -2167,10 +3236,14 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "axisSoftMax": 5,
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -2179,6 +3252,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -2202,7 +3276,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               }
             ]
           },
@@ -2234,26 +3309,28 @@
         "y": 27
       },
       "id": 342,
-      "links": [],
       "options": {
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "multi"
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
         }
       },
-      "pluginVersion": "8.3.3",
+      "pluginVersion": "12.1.0-88993",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "rate(pg_stat_database_xact_commit_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+          "expr": "rate(pg_stat_database_xact_commit_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -2264,10 +3341,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "rate(pg_stat_database_xact_rollback_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+          "expr": "rate(pg_stat_database_xact_rollback_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -2279,10 +3356,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "rate(pg_stat_database_deadlocks_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+          "expr": "rate(pg_stat_database_deadlocks_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -2298,7 +3375,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "grafanacloud-prom"
       },
       "description": "",
       "fieldConfig": {
@@ -2307,10 +3384,14 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "axisSoftMax": 5,
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -2319,6 +3400,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -2342,7 +3424,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               }
             ]
           },
@@ -2377,26 +3460,28 @@
         "y": 27
       },
       "id": 331,
-      "links": [],
       "options": {
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "multi"
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
         }
       },
-      "pluginVersion": "8.3.3",
+      "pluginVersion": "12.1.0-88993",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "rate(pg_stat_database_conflicts_confl_tablespace_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+          "expr": "rate(pg_stat_database_conflicts_confl_tablespace_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -2407,10 +3492,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "rate(pg_stat_database_conflicts_confl_lock_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+          "expr": "rate(pg_stat_database_conflicts_confl_lock_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -2422,10 +3507,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "rate(pg_stat_database_conflicts_confl_snapshot_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+          "expr": "rate(pg_stat_database_conflicts_confl_snapshot_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -2437,10 +3522,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "rate(pg_stat_database_conflicts_confl_bufferpin_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+          "expr": "rate(pg_stat_database_conflicts_confl_bufferpin_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -2452,10 +3537,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "rate(pg_stat_database_conflicts_confl_deadlock_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+          "expr": "rate(pg_stat_database_conflicts_confl_deadlock_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -2471,7 +3556,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "grafanacloud-prom"
       },
       "fieldConfig": {
         "defaults": {
@@ -2500,7 +3585,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "green",
@@ -2527,6 +3613,7 @@
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -2535,18 +3622,20 @@
           "limit": 2,
           "values": false
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.3.3",
+      "pluginVersion": "12.1.0-88993",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "pg_settings_default_transaction_read_only{supabase_project_ref=\"$project\"}",
+          "expr": "pg_settings_default_transaction_read_only{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -2559,7 +3648,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "grafanacloud-prom"
       },
       "fieldConfig": {
         "defaults": {
@@ -2588,7 +3677,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "green",
@@ -2615,6 +3705,7 @@
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "last"
@@ -2622,18 +3713,20 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.3.3",
+      "pluginVersion": "12.1.0-88993",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "pg_status_in_recovery{supabase_project_ref=\"$project\"}",
+          "expr": "pg_status_in_recovery{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -2658,7 +3751,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "grafanacloud-prom"
       },
       "description": "Realtime replication status",
       "fieldConfig": {
@@ -2715,6 +3808,7 @@
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -2722,18 +3816,20 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.3.3",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "replication_realtime_slot_status{supabase_project_ref=\"$project\"}",
+          "expr": "replication_realtime_slot_status{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -2745,7 +3841,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "grafanacloud-prom"
       },
       "description": "",
       "fieldConfig": {
@@ -2754,10 +3850,14 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "axisSoftMax": 20,
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 40,
             "gradientMode": "none",
@@ -2766,6 +3866,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -2804,26 +3905,28 @@
         "y": 35
       },
       "id": 329,
-      "links": [],
       "options": {
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
         }
       },
-      "pluginVersion": "8.3.3",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "replication_realtime_lag_bytes{supabase_project_ref=\"$project\"}",
+          "expr": "replication_realtime_lag_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -2851,7 +3954,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "grafanacloud-prom"
       },
       "description": "",
       "fieldConfig": {
@@ -2927,7 +4030,6 @@
         "y": 39
       },
       "id": 332,
-      "links": [],
       "options": {
         "legend": {
           "calcs": [],
@@ -2943,10 +4045,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "rate(pg_stat_bgwriter_checkpoints_timed_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+          "expr": "rate(pg_stat_bgwriter_checkpoints_timed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -2957,10 +4059,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "rate(pg_stat_bgwriter_checkpoints_req_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+          "expr": "rate(pg_stat_bgwriter_checkpoints_req_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -2972,10 +4074,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "rate(pg_stat_bgwriter_checkpoint_write_time_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+          "expr": "rate(pg_stat_bgwriter_checkpoint_write_time_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -2987,10 +4089,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "rate(pg_stat_bgwriter_checkpoint_sync_time_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+          "expr": "rate(pg_stat_bgwriter_checkpoint_sync_time_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -3006,7 +4108,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "grafanacloud-prom"
       },
       "description": "",
       "fieldConfig": {
@@ -3078,7 +4180,6 @@
         "y": 39
       },
       "id": 333,
-      "links": [],
       "options": {
         "legend": {
           "calcs": [],
@@ -3094,10 +4195,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "rate(pg_stat_bgwriter_buffers_checkpoint_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+          "expr": "rate(pg_stat_bgwriter_buffers_checkpoint_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -3108,10 +4209,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "rate(pg_stat_bgwriter_buffers_clean_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+          "expr": "rate(pg_stat_bgwriter_buffers_clean_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -3123,10 +4224,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "rate(pg_stat_bgwriter_buffers_backend_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+          "expr": "rate(pg_stat_bgwriter_buffers_backend_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -3138,10 +4239,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "rate(pg_stat_bgwriter_buffers_alloc_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+          "expr": "rate(pg_stat_bgwriter_buffers_alloc_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -3157,7 +4258,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "grafanacloud-prom"
       },
       "description": "",
       "fieldConfig": {
@@ -3229,7 +4330,6 @@
         "y": 39
       },
       "id": 340,
-      "links": [],
       "options": {
         "legend": {
           "calcs": [],
@@ -3245,10 +4345,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "rate(pg_stat_bgwriter_maxwritten_clean_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+          "expr": "rate(pg_stat_bgwriter_maxwritten_clean_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -3259,10 +4359,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "exemplar": false,
-          "expr": "rate(pg_stat_bgwriter_buffers_backend_fsync_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+          "expr": "rate(pg_stat_bgwriter_buffers_backend_fsync_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -3277,10 +4377,6 @@
     },
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -3290,26 +4386,10 @@
       "id": 265,
       "panels": [
         {
-          "aliasColors": {
-            "Idle - Waiting for something to happen": "#052B51",
-            "guest": "#9AC48A",
-            "idle": "#052B51",
-            "iowait": "#EAB839",
-            "irq": "#BF1B00",
-            "nice": "#C15C17",
-            "softirq": "#E24D42",
-            "steal": "#FCE2DE",
-            "system": "#508642",
-            "user": "#5195CE"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "decimals": 2,
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -3318,48 +4398,25 @@
             },
             "overrides": []
           },
-          "fill": 4,
-          "fillGradient": 0,
           "gridPos": {
             "h": 12,
             "w": 12,
             "x": 0,
             "y": 3
           },
-          "hiddenSeries": false,
           "id": 3,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": 250,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": true,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": true,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode=\"system\",supabase_project_ref=\"$project\"}[$__rate_interval])) * 100",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode=\"system\",supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
               "format": "time_series",
               "interval": "10s",
               "intervalFactor": 1,
@@ -3368,7 +4425,11 @@
               "step": 240
             },
             {
-              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='user',supabase_project_ref=\"$project\"}[$__rate_interval])) * 100",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='user',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "User - Normal processes executing in user mode",
@@ -3376,7 +4437,11 @@
               "step": 240
             },
             {
-              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='nice',supabase_project_ref=\"$project\"}[$__rate_interval])) * 100",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='nice',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Nice - Niced processes executing in user mode",
@@ -3384,7 +4449,11 @@
               "step": 240
             },
             {
-              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='idle',supabase_project_ref=\"$project\"}[$__rate_interval])) * 100",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='idle',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Idle - Waiting for something to happen",
@@ -3392,7 +4461,11 @@
               "step": 240
             },
             {
-              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='iowait',supabase_project_ref=\"$project\"}[$__rate_interval])) * 100",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='iowait',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Iowait - Waiting for I/O to complete",
@@ -3400,7 +4473,11 @@
               "step": 240
             },
             {
-              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='irq',supabase_project_ref=\"$project\"}[$__rate_interval])) * 100",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='irq',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Irq - Servicing interrupts",
@@ -3408,7 +4485,11 @@
               "step": 240
             },
             {
-              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='softirq',supabase_project_ref=\"$project\"}[$__rate_interval])) * 100",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='softirq',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Softirq - Servicing softirqs",
@@ -3416,7 +4497,11 @@
               "step": 240
             },
             {
-              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='steal',supabase_project_ref=\"$project\"}[$__rate_interval])) * 100",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='steal',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Steal - Time spent in other operating systems when running in a virtualized environment",
@@ -3424,7 +4509,11 @@
               "step": 240
             },
             {
-              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='guest',supabase_project_ref=\"$project\"}[$__rate_interval])) * 100",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='guest',supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])) * 100",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Guest - Time spent running a virtual CPU for a guest operating system",
@@ -3432,69 +4521,14 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "CPU",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "percentage",
-              "logBase": 1,
-              "max": "100",
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "Apps": "#629E51",
-            "Buffers": "#614D93",
-            "Cache": "#6D1F62",
-            "Cached": "#511749",
-            "Committed": "#508642",
-            "Free": "#0A437C",
-            "Hardware Corrupted - Amount of RAM that the kernel identified as corrupted / not working": "#CFFAFF",
-            "Inactive": "#584477",
-            "PageTables": "#0A50A1",
-            "Page_Tables": "#0A50A1",
-            "RAM_Free": "#E0F9D7",
-            "Slab": "#806EB7",
-            "Slab_Cache": "#E0752D",
-            "Swap": "#BF1B00",
-            "Swap - Swap memory usage": "#BF1B00",
-            "Swap_Cache": "#C15C17",
-            "Swap_Free": "#2F575E",
-            "Unused": "#EAB839",
-            "Unused - Free memory unassigned": "#052B51"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "decimals": 2,
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -3503,53 +4537,25 @@
             },
             "overrides": []
           },
-          "fill": 4,
-          "fillGradient": 0,
           "gridPos": {
             "h": 12,
             "w": 12,
             "x": 12,
             "y": 3
           },
-          "hiddenSeries": false,
           "id": 24,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": 350,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "/.*Hardware Corrupted - *./",
-              "stack": false
-            }
-          ],
-          "spaceLength": 10,
-          "stack": true,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_memory_MemTotal_bytes{supabase_project_ref=\"$project\"} - node_memory_MemFree_bytes{supabase_project_ref=\"$project\"} - node_memory_Buffers_bytes{supabase_project_ref=\"$project\"} - node_memory_Cached_bytes{supabase_project_ref=\"$project\"} - node_memory_Slab_bytes{supabase_project_ref=\"$project\"} - node_memory_PageTables_bytes{supabase_project_ref=\"$project\"} - node_memory_SwapCached_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_MemTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_MemFree_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_Buffers_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_Cached_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_Slab_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_PageTables_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_SwapCached_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -3558,7 +4564,11 @@
               "step": 240
             },
             {
-              "expr": "node_memory_PageTables_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_PageTables_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -3567,7 +4577,11 @@
               "step": 240
             },
             {
-              "expr": "node_memory_SwapCached_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_SwapCached_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "SwapCache - Memory that keeps track of pages that have been fetched from swap but not yet been modified",
@@ -3575,7 +4589,11 @@
               "step": 240
             },
             {
-              "expr": "node_memory_Slab_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_Slab_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -3584,7 +4602,11 @@
               "step": 240
             },
             {
-              "expr": "node_memory_Cached_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_Cached_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -3593,7 +4615,11 @@
               "step": 240
             },
             {
-              "expr": "node_memory_Buffers_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_Buffers_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -3602,7 +4628,11 @@
               "step": 240
             },
             {
-              "expr": "node_memory_MemFree_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_MemFree_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -3611,7 +4641,11 @@
               "step": 240
             },
             {
-              "expr": "(node_memory_SwapTotal_bytes{supabase_project_ref=\"$project\"} - node_memory_SwapFree_bytes{supabase_project_ref=\"$project\"})",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "(node_memory_SwapTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"} - node_memory_SwapFree_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"})",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -3620,7 +4654,11 @@
               "step": 240
             },
             {
-              "expr": "node_memory_HardwareCorrupted_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_HardwareCorrupted_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -3629,51 +4667,13 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Memory Stack",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "bytes",
-              "label": "bytes",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "receive_packets_eth0": "#7EB26D",
-            "receive_packets_lo": "#E24D42",
-            "transmit_packets_eth0": "#7EB26D",
-            "transmit_packets_lo": "#E24D42"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "fieldConfig": {
             "defaults": {
@@ -3682,52 +4682,24 @@
             },
             "overrides": []
           },
-          "fill": 4,
-          "fillGradient": 0,
           "gridPos": {
             "h": 12,
             "w": 12,
             "x": 0,
             "y": 15
           },
-          "hiddenSeries": false,
           "id": 84,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:5871",
-              "alias": "/.*Trans.*/",
-              "transform": "negative-Y"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_network_receive_bytes_total{supabase_project_ref=\"$project\"}[$__rate_interval])*8",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_network_receive_bytes_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])*8",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{device}} - Receive",
@@ -3735,7 +4707,11 @@
               "step": 240
             },
             {
-              "expr": "rate(node_network_transmit_bytes_total{supabase_project_ref=\"$project\"}[$__rate_interval])*8",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_network_transmit_bytes_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])*8",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{device}} - Transmit",
@@ -3743,49 +4719,14 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Network Traffic",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:5884",
-              "format": "bps",
-              "label": "bits out (-) / in (+)",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:5885",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "decimals": 3,
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -3794,50 +4735,25 @@
             },
             "overrides": []
           },
-          "fill": 4,
-          "fillGradient": 0,
           "gridPos": {
             "h": 12,
             "w": 12,
             "x": 12,
             "y": 15
           },
-          "height": "",
-          "hiddenSeries": false,
           "id": 156,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sort": "current",
-            "sortDesc": false,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_filesystem_size_bytes{supabase_project_ref=\"$project\",device!~'rootfs'} - node_filesystem_avail_bytes{supabase_project_ref=\"$project\",device!~'rootfs'}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_filesystem_size_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'} - node_filesystem_avail_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{mountpoint}}",
@@ -3845,46 +4761,13 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Disk Space Used",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "bytes",
-              "label": "bytes",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "description": "",
           "fieldConfig": {
@@ -3894,193 +4777,50 @@
             },
             "overrides": []
           },
-          "fill": 2,
-          "fillGradient": 0,
           "gridPos": {
             "h": 12,
             "w": 12,
             "x": 0,
             "y": 27
           },
-          "hiddenSeries": false,
           "id": 229,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideZero": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "/.*Read.*/",
-              "transform": "negative-Y"
-            },
-            {
-              "alias": "/.*sda_.*/",
-              "color": "#7EB26D"
-            },
-            {
-              "alias": "/.*sdb_.*/",
-              "color": "#EAB839"
-            },
-            {
-              "alias": "/.*sdc_.*/",
-              "color": "#6ED0E0"
-            },
-            {
-              "alias": "/.*sdd_.*/",
-              "color": "#EF843C"
-            },
-            {
-              "alias": "/.*sde_.*/",
-              "color": "#E24D42"
-            },
-            {
-              "alias": "/.*sda1.*/",
-              "color": "#584477"
-            },
-            {
-              "alias": "/.*sda2_.*/",
-              "color": "#BA43A9"
-            },
-            {
-              "alias": "/.*sda3_.*/",
-              "color": "#F4D598"
-            },
-            {
-              "alias": "/.*sdb1.*/",
-              "color": "#0A50A1"
-            },
-            {
-              "alias": "/.*sdb2.*/",
-              "color": "#BF1B00"
-            },
-            {
-              "alias": "/.*sdb2.*/",
-              "color": "#BF1B00"
-            },
-            {
-              "alias": "/.*sdb3.*/",
-              "color": "#E0752D"
-            },
-            {
-              "alias": "/.*sdc1.*/",
-              "color": "#962D82"
-            },
-            {
-              "alias": "/.*sdc2.*/",
-              "color": "#614D93"
-            },
-            {
-              "alias": "/.*sdc3.*/",
-              "color": "#9AC48A"
-            },
-            {
-              "alias": "/.*sdd1.*/",
-              "color": "#65C5DB"
-            },
-            {
-              "alias": "/.*sdd2.*/",
-              "color": "#F9934E"
-            },
-            {
-              "alias": "/.*sdd3.*/",
-              "color": "#EA6460"
-            },
-            {
-              "alias": "/.*sde1.*/",
-              "color": "#E0F9D7"
-            },
-            {
-              "alias": "/.*sdd2.*/",
-              "color": "#FCEACA"
-            },
-            {
-              "alias": "/.*sde3.*/",
-              "color": "#F9E2D2"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_disk_reads_completed_total{supabase_project_ref=\"$project\",device=~\"$diskdevices\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_disk_reads_completed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device=~\"$diskdevices\"}[$__rate_interval])",
               "intervalFactor": 1,
               "legendFormat": "{{device}} - Reads completed",
               "refId": "A",
               "step": 240
             },
             {
-              "expr": "rate(node_disk_writes_completed_total{supabase_project_ref=\"$project\",device=~\"$diskdevices\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_disk_writes_completed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device=~\"$diskdevices\"}[$__rate_interval])",
               "intervalFactor": 1,
               "legendFormat": "{{device}} - Writes completed",
               "refId": "B",
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Disk IOps",
-          "tooltip": {
-            "shared": false,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "iops",
-              "label": "IO read (-) / write (+)",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "io time": "#890F02"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "decimals": 3,
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -4089,72 +4829,25 @@
             },
             "overrides": []
           },
-          "fill": 4,
-          "fillGradient": 0,
           "gridPos": {
             "h": 12,
             "w": 12,
             "x": 12,
             "y": 27
           },
-          "hiddenSeries": false,
           "id": 42,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "/.*read*./",
-              "transform": "negative-Y"
-            },
-            {
-              "alias": "/.*sda.*/",
-              "color": "#7EB26D"
-            },
-            {
-              "alias": "/.*sdb.*/",
-              "color": "#EAB839"
-            },
-            {
-              "alias": "/.*sdc.*/",
-              "color": "#6ED0E0"
-            },
-            {
-              "alias": "/.*sdd.*/",
-              "color": "#EF843C"
-            },
-            {
-              "alias": "/.*sde.*/",
-              "color": "#E24D42"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_disk_read_bytes_total{supabase_project_ref=\"$project\",device=~\"$diskdevices\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_disk_read_bytes_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device=~\"$diskdevices\"}[$__rate_interval])",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -4163,7 +4856,11 @@
               "step": 240
             },
             {
-              "expr": "rate(node_disk_written_bytes_total{supabase_project_ref=\"$project\",device=~\"$diskdevices\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_disk_written_bytes_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device=~\"$diskdevices\"}[$__rate_interval])",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -4172,52 +4869,14 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "I/O Usage Read / Write",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": false,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:965",
-              "format": "Bps",
-              "label": "bytes read (-) / write (+)",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:966",
-              "format": "ms",
-              "label": "",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "io time": "#890F02"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "decimals": 3,
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -4226,47 +4885,25 @@
             },
             "overrides": []
           },
-          "fill": 4,
-          "fillGradient": 0,
           "gridPos": {
             "h": 12,
             "w": 12,
             "x": 0,
             "y": 39
           },
-          "hiddenSeries": false,
           "id": 127,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_disk_io_time_seconds_total{supabase_project_ref=\"$project\",device=~\"$diskdevices\"} [$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_disk_io_time_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device=~\"$diskdevices\"} [$__rate_interval])",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -4276,40 +4913,8 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "I/O Utilization",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": false,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:1041",
-              "format": "percentunit",
-              "label": "%util",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:1042",
-              "format": "s",
-              "label": "",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         }
       ],
       "title": "CPU / Memory / Net / Disk",
@@ -4317,10 +4922,6 @@
     },
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -4330,74 +4931,32 @@
       "id": 266,
       "panels": [
         {
-          "aliasColors": {
-            "Apps": "#629E51",
-            "Buffers": "#614D93",
-            "Cache": "#6D1F62",
-            "Cached": "#511749",
-            "Committed": "#508642",
-            "Free": "#0A437C",
-            "Hardware Corrupted - Amount of RAM that the kernel identified as corrupted / not working": "#CFFAFF",
-            "Inactive": "#584477",
-            "PageTables": "#0A50A1",
-            "Page_Tables": "#0A50A1",
-            "RAM_Free": "#E0F9D7",
-            "Slab": "#806EB7",
-            "Slab_Cache": "#E0752D",
-            "Swap": "#BF1B00",
-            "Swap_Cache": "#C15C17",
-            "Swap_Free": "#2F575E",
-            "Unused": "#EAB839"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "decimals": 2,
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 70
           },
-          "hiddenSeries": false,
           "id": 136,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": 350,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 2,
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": true,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_memory_Inactive_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_Inactive_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Inactive - Memory which has been less recently used.  It is more eligible to be reclaimed for other purposes",
@@ -4405,7 +4964,11 @@
               "step": 240
             },
             {
-              "expr": "node_memory_Active_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_Active_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Active - Memory that has been used more recently and usually not reclaimed unless absolutely necessary",
@@ -4413,116 +4976,36 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Memory Active / Inactive",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "cumulative"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "bytes",
-              "label": "bytes",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "Apps": "#629E51",
-            "Buffers": "#614D93",
-            "Cache": "#6D1F62",
-            "Cached": "#511749",
-            "Committed": "#508642",
-            "Free": "#0A437C",
-            "Hardware Corrupted - Amount of RAM that the kernel identified as corrupted / not working": "#CFFAFF",
-            "Inactive": "#584477",
-            "PageTables": "#0A50A1",
-            "Page_Tables": "#0A50A1",
-            "RAM_Free": "#E0F9D7",
-            "Slab": "#806EB7",
-            "Slab_Cache": "#E0752D",
-            "Swap": "#BF1B00",
-            "Swap_Cache": "#C15C17",
-            "Swap_Free": "#2F575E",
-            "Unused": "#EAB839"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "decimals": 2,
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 70
           },
-          "hiddenSeries": false,
           "id": 135,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": 350,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "/.*Committed_AS - *./"
-            },
-            {
-              "alias": "/.*CommitLimit - *./",
-              "color": "#BF1B00",
-              "fill": 0
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_memory_Committed_AS_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_Committed_AS_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Committed_AS - Amount of memory presently allocated on the system",
@@ -4530,7 +5013,11 @@
               "step": 240
             },
             {
-              "expr": "node_memory_CommitLimit_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_CommitLimit_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "CommitLimit - Amount of  memory currently available to be allocated on the system",
@@ -4538,107 +5025,36 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Memory Commited",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "cumulative"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "bytes",
-              "label": "bytes",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "Apps": "#629E51",
-            "Buffers": "#614D93",
-            "Cache": "#6D1F62",
-            "Cached": "#511749",
-            "Committed": "#508642",
-            "Free": "#0A437C",
-            "Hardware Corrupted - Amount of RAM that the kernel identified as corrupted / not working": "#CFFAFF",
-            "Inactive": "#584477",
-            "PageTables": "#0A50A1",
-            "Page_Tables": "#0A50A1",
-            "RAM_Free": "#E0F9D7",
-            "Slab": "#806EB7",
-            "Slab_Cache": "#E0752D",
-            "Swap": "#BF1B00",
-            "Swap_Cache": "#C15C17",
-            "Swap_Free": "#2F575E",
-            "Unused": "#EAB839"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "decimals": 2,
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 80
           },
-          "hiddenSeries": false,
           "id": 191,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": 350,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": true,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_memory_Inactive_file_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_Inactive_file_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -4647,7 +5063,11 @@
               "step": 240
             },
             {
-              "expr": "node_memory_Inactive_anon_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_Inactive_anon_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -4656,7 +5076,11 @@
               "step": 240
             },
             {
-              "expr": "node_memory_Active_file_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_Active_file_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -4665,7 +5089,11 @@
               "step": 240
             },
             {
-              "expr": "node_memory_Active_anon_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_Active_anon_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -4674,108 +5102,36 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Memory Active / Inactive Detail",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "cumulative"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "bytes",
-              "label": "bytes",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "bytes",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "Active": "#99440A",
-            "Buffers": "#58140C",
-            "Cache": "#6D1F62",
-            "Cached": "#511749",
-            "Committed": "#508642",
-            "Dirty": "#6ED0E0",
-            "Free": "#B7DBAB",
-            "Inactive": "#EA6460",
-            "Mapped": "#052B51",
-            "PageTables": "#0A50A1",
-            "Page_Tables": "#0A50A1",
-            "Slab_Cache": "#EAB839",
-            "Swap": "#BF1B00",
-            "Swap_Cache": "#C15C17",
-            "Total": "#511749",
-            "Total RAM": "#052B51",
-            "Total RAM + Swap": "#052B51",
-            "Total Swap": "#614D93",
-            "VmallocUsed": "#EA6460"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "decimals": 2,
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 80
           },
-          "hiddenSeries": false,
           "id": 130,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 2,
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_memory_Writeback_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_Writeback_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Writeback - Memory which is actively being written back to disk",
@@ -4783,7 +5139,11 @@
               "step": 240
             },
             {
-              "expr": "node_memory_WritebackTmp_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_WritebackTmp_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "WritebackTmp - Memory used by FUSE for temporary writeback buffers",
@@ -4791,7 +5151,11 @@
               "step": 240
             },
             {
-              "expr": "node_memory_Dirty_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_Dirty_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Dirty - Memory which is waiting to get written back to the disk",
@@ -4799,118 +5163,36 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Memory Writeback and Dirty",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "bytes",
-              "label": "bytes",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "Apps": "#629E51",
-            "Buffers": "#614D93",
-            "Cache": "#6D1F62",
-            "Cached": "#511749",
-            "Committed": "#508642",
-            "Free": "#0A437C",
-            "Hardware Corrupted - Amount of RAM that the kernel identified as corrupted / not working": "#CFFAFF",
-            "Inactive": "#584477",
-            "PageTables": "#0A50A1",
-            "Page_Tables": "#0A50A1",
-            "RAM_Free": "#E0F9D7",
-            "Slab": "#806EB7",
-            "Slab_Cache": "#E0752D",
-            "Swap": "#BF1B00",
-            "Swap_Cache": "#C15C17",
-            "Swap_Free": "#2F575E",
-            "Unused": "#EAB839"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "decimals": 2,
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 90
           },
-          "hiddenSeries": false,
           "id": 138,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": 350,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:4131",
-              "alias": "ShmemHugePages - Memory used by shared memory (shmem) and tmpfs allocated  with huge pages",
-              "fill": 0
-            },
-            {
-              "$$hashKey": "object:4138",
-              "alias": "ShmemHugePages - Memory used by shared memory (shmem) and tmpfs allocated  with huge pages",
-              "fill": 0
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_memory_Mapped_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_Mapped_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Mapped - Used memory in mapped pages files which have been mmaped, such as libraries",
@@ -4918,7 +5200,11 @@
               "step": 240
             },
             {
-              "expr": "node_memory_Shmem_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_Shmem_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Shmem - Used shared memory (shared between several processes, thus including RAM disks)",
@@ -4926,7 +5212,11 @@
               "step": 240
             },
             {
-              "expr": "node_memory_ShmemHugePages_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_ShmemHugePages_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -4935,7 +5225,11 @@
               "step": 240
             },
             {
-              "expr": "node_memory_ShmemPmdMapped_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_ShmemPmdMapped_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -4944,110 +5238,36 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Memory Shared and Mapped",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "cumulative"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:4106",
-              "format": "bytes",
-              "label": "bytes",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:4107",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "Active": "#99440A",
-            "Buffers": "#58140C",
-            "Cache": "#6D1F62",
-            "Cached": "#511749",
-            "Committed": "#508642",
-            "Dirty": "#6ED0E0",
-            "Free": "#B7DBAB",
-            "Inactive": "#EA6460",
-            "Mapped": "#052B51",
-            "PageTables": "#0A50A1",
-            "Page_Tables": "#0A50A1",
-            "Slab_Cache": "#EAB839",
-            "Swap": "#BF1B00",
-            "Swap_Cache": "#C15C17",
-            "Total": "#511749",
-            "Total RAM": "#052B51",
-            "Total RAM + Swap": "#052B51",
-            "Total Swap": "#614D93",
-            "VmallocUsed": "#EA6460"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "decimals": 2,
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 90
           },
-          "hiddenSeries": false,
           "id": 131,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 2,
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": true,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_memory_SUnreclaim_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_SUnreclaim_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "SUnreclaim - Part of Slab, that cannot be reclaimed on memory pressure",
@@ -5055,7 +5275,11 @@
               "step": 240
             },
             {
-              "expr": "node_memory_SReclaimable_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_SReclaimable_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "SReclaimable - Part of Slab, that might be reclaimed, such as caches",
@@ -5063,107 +5287,36 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Memory Slab",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "bytes",
-              "label": "bytes",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "Active": "#99440A",
-            "Buffers": "#58140C",
-            "Cache": "#6D1F62",
-            "Cached": "#511749",
-            "Committed": "#508642",
-            "Dirty": "#6ED0E0",
-            "Free": "#B7DBAB",
-            "Inactive": "#EA6460",
-            "Mapped": "#052B51",
-            "PageTables": "#0A50A1",
-            "Page_Tables": "#0A50A1",
-            "Slab_Cache": "#EAB839",
-            "Swap": "#BF1B00",
-            "Swap_Cache": "#C15C17",
-            "Total": "#511749",
-            "Total RAM": "#052B51",
-            "Total RAM + Swap": "#052B51",
-            "VmallocUsed": "#EA6460"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "decimals": 2,
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 100
           },
-          "hiddenSeries": false,
           "id": 70,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_memory_VmallocChunk_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_VmallocChunk_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -5172,7 +5325,11 @@
               "step": 240
             },
             {
-              "expr": "node_memory_VmallocTotal_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_VmallocTotal_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -5181,7 +5338,11 @@
               "step": 240
             },
             {
-              "expr": "node_memory_VmallocUsed_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_VmallocUsed_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -5190,107 +5351,36 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Memory Vmalloc",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "bytes",
-              "label": "bytes",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "Apps": "#629E51",
-            "Buffers": "#614D93",
-            "Cache": "#6D1F62",
-            "Cached": "#511749",
-            "Committed": "#508642",
-            "Free": "#0A437C",
-            "Hardware Corrupted - Amount of RAM that the kernel identified as corrupted / not working": "#CFFAFF",
-            "Inactive": "#584477",
-            "PageTables": "#0A50A1",
-            "Page_Tables": "#0A50A1",
-            "RAM_Free": "#E0F9D7",
-            "Slab": "#806EB7",
-            "Slab_Cache": "#E0752D",
-            "Swap": "#BF1B00",
-            "Swap_Cache": "#C15C17",
-            "Swap_Free": "#2F575E",
-            "Unused": "#EAB839"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "decimals": 2,
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 100
           },
-          "hiddenSeries": false,
           "id": 159,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": 350,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_memory_Bounce_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_Bounce_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Bounce - Memory used for block device bounce buffers",
@@ -5298,112 +5388,36 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Memory Bounce",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "cumulative"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "bytes",
-              "label": "bytes",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "Active": "#99440A",
-            "Buffers": "#58140C",
-            "Cache": "#6D1F62",
-            "Cached": "#511749",
-            "Committed": "#508642",
-            "Dirty": "#6ED0E0",
-            "Free": "#B7DBAB",
-            "Inactive": "#EA6460",
-            "Mapped": "#052B51",
-            "PageTables": "#0A50A1",
-            "Page_Tables": "#0A50A1",
-            "Slab_Cache": "#EAB839",
-            "Swap": "#BF1B00",
-            "Swap_Cache": "#C15C17",
-            "Total": "#511749",
-            "Total RAM": "#052B51",
-            "Total RAM + Swap": "#052B51",
-            "VmallocUsed": "#EA6460"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "decimals": 2,
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 110
           },
-          "hiddenSeries": false,
           "id": 129,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "/.*Inactive *./",
-              "transform": "negative-Y"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_memory_AnonHugePages_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_AnonHugePages_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "AnonHugePages - Memory in anonymous huge pages",
@@ -5411,7 +5425,11 @@
               "step": 240
             },
             {
-              "expr": "node_memory_AnonPages_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_AnonPages_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "AnonPages - Memory in user pages not backed by files",
@@ -5419,107 +5437,36 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Memory Anonymous",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "bytes",
-              "label": "bytes",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "Apps": "#629E51",
-            "Buffers": "#614D93",
-            "Cache": "#6D1F62",
-            "Cached": "#511749",
-            "Committed": "#508642",
-            "Free": "#0A437C",
-            "Hardware Corrupted - Amount of RAM that the kernel identified as corrupted / not working": "#CFFAFF",
-            "Inactive": "#584477",
-            "PageTables": "#0A50A1",
-            "Page_Tables": "#0A50A1",
-            "RAM_Free": "#E0F9D7",
-            "Slab": "#806EB7",
-            "Slab_Cache": "#E0752D",
-            "Swap": "#BF1B00",
-            "Swap_Cache": "#C15C17",
-            "Swap_Free": "#2F575E",
-            "Unused": "#EAB839"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "decimals": 2,
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 110
           },
-          "hiddenSeries": false,
           "id": 160,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": 350,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 2,
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_memory_KernelStack_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_KernelStack_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "KernelStack - Kernel memory stack. This is not reclaimable",
@@ -5527,7 +5474,11 @@
               "step": 240
             },
             {
-              "expr": "node_memory_Percpu_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_Percpu_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -5536,107 +5487,36 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Memory Kernel / CPU",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "cumulative"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "bytes",
-              "label": "bytes",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "Active": "#99440A",
-            "Buffers": "#58140C",
-            "Cache": "#6D1F62",
-            "Cached": "#511749",
-            "Committed": "#508642",
-            "Dirty": "#6ED0E0",
-            "Free": "#B7DBAB",
-            "Inactive": "#EA6460",
-            "Mapped": "#052B51",
-            "PageTables": "#0A50A1",
-            "Page_Tables": "#0A50A1",
-            "Slab_Cache": "#EAB839",
-            "Swap": "#BF1B00",
-            "Swap_Cache": "#C15C17",
-            "Total": "#511749",
-            "Total RAM": "#806EB7",
-            "Total RAM + Swap": "#806EB7",
-            "VmallocUsed": "#EA6460"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "decimals": 2,
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 120
           },
-          "hiddenSeries": false,
           "id": 140,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_memory_HugePages_Free{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_HugePages_Free{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "HugePages_Free - Huge pages in the pool that are not yet allocated",
@@ -5644,7 +5524,11 @@
               "step": 240
             },
             {
-              "expr": "node_memory_HugePages_Rsvd{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_HugePages_Rsvd{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "HugePages_Rsvd - Huge pages for which a commitment to allocate from the pool has been made, but no allocation has yet been made",
@@ -5652,7 +5536,11 @@
               "step": 240
             },
             {
-              "expr": "node_memory_HugePages_Surp{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_HugePages_Surp{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "HugePages_Surp - Huge pages in the pool above the value in /proc/sys/vm/nr_hugepages",
@@ -5660,108 +5548,36 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Memory HugePages Counter",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "pages",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": "",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "Active": "#99440A",
-            "Buffers": "#58140C",
-            "Cache": "#6D1F62",
-            "Cached": "#511749",
-            "Committed": "#508642",
-            "Dirty": "#6ED0E0",
-            "Free": "#B7DBAB",
-            "Inactive": "#EA6460",
-            "Mapped": "#052B51",
-            "PageTables": "#0A50A1",
-            "Page_Tables": "#0A50A1",
-            "Slab_Cache": "#EAB839",
-            "Swap": "#BF1B00",
-            "Swap_Cache": "#C15C17",
-            "Total": "#511749",
-            "Total RAM": "#806EB7",
-            "Total RAM + Swap": "#806EB7",
-            "VmallocUsed": "#EA6460"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "decimals": 2,
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 120
           },
-          "hiddenSeries": false,
           "id": 71,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 2,
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_memory_HugePages_Total{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_HugePages_Total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "HugePages - Total size of the pool of huge pages",
@@ -5769,7 +5585,11 @@
               "step": 240
             },
             {
-              "expr": "node_memory_Hugepagesize_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_Hugepagesize_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Hugepagesize - Huge Page size",
@@ -5777,110 +5597,36 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Memory HugePages Size",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "bytes",
-              "label": "bytes",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": "",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "Active": "#99440A",
-            "Buffers": "#58140C",
-            "Cache": "#6D1F62",
-            "Cached": "#511749",
-            "Committed": "#508642",
-            "Dirty": "#6ED0E0",
-            "Free": "#B7DBAB",
-            "Inactive": "#EA6460",
-            "Mapped": "#052B51",
-            "PageTables": "#0A50A1",
-            "Page_Tables": "#0A50A1",
-            "Slab_Cache": "#EAB839",
-            "Swap": "#BF1B00",
-            "Swap_Cache": "#C15C17",
-            "Total": "#511749",
-            "Total RAM": "#052B51",
-            "Total RAM + Swap": "#052B51",
-            "VmallocUsed": "#EA6460"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "decimals": 2,
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 130
           },
-          "hiddenSeries": false,
           "id": 128,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": false,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_memory_DirectMap1G_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_DirectMap1G_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "DirectMap1G - Amount of pages mapped as this size",
@@ -5888,7 +5634,11 @@
               "step": 240
             },
             {
-              "expr": "node_memory_DirectMap2M_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_DirectMap2M_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -5897,7 +5647,11 @@
               "step": 240
             },
             {
-              "expr": "node_memory_DirectMap4k_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_DirectMap4k_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -5906,107 +5660,36 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Memory DirectMap",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "bytes",
-              "label": "bytes",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "Apps": "#629E51",
-            "Buffers": "#614D93",
-            "Cache": "#6D1F62",
-            "Cached": "#511749",
-            "Committed": "#508642",
-            "Free": "#0A437C",
-            "Hardware Corrupted - Amount of RAM that the kernel identified as corrupted / not working": "#CFFAFF",
-            "Inactive": "#584477",
-            "PageTables": "#0A50A1",
-            "Page_Tables": "#0A50A1",
-            "RAM_Free": "#E0F9D7",
-            "Slab": "#806EB7",
-            "Slab_Cache": "#E0752D",
-            "Swap": "#BF1B00",
-            "Swap_Cache": "#C15C17",
-            "Swap_Free": "#2F575E",
-            "Unused": "#EAB839"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "decimals": 2,
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 130
           },
-          "hiddenSeries": false,
           "id": 137,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": 350,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_memory_Unevictable_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_Unevictable_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Unevictable - Amount of unevictable memory that can't be swapped out for a variety of reasons",
@@ -6014,7 +5697,11 @@
               "step": 240
             },
             {
-              "expr": "node_memory_Mlocked_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_Mlocked_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "MLocked - Size of pages locked to memory using the mlock() system call",
@@ -6022,108 +5709,36 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Memory Unevictable and MLocked",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "cumulative"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "bytes",
-              "label": "bytes",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "Active": "#99440A",
-            "Buffers": "#58140C",
-            "Cache": "#6D1F62",
-            "Cached": "#511749",
-            "Committed": "#508642",
-            "Dirty": "#6ED0E0",
-            "Free": "#B7DBAB",
-            "Inactive": "#EA6460",
-            "Mapped": "#052B51",
-            "PageTables": "#0A50A1",
-            "Page_Tables": "#0A50A1",
-            "Slab_Cache": "#EAB839",
-            "Swap": "#BF1B00",
-            "Swap_Cache": "#C15C17",
-            "Total": "#511749",
-            "Total RAM": "#052B51",
-            "Total RAM + Swap": "#052B51",
-            "Total Swap": "#614D93",
-            "VmallocUsed": "#EA6460"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "decimals": 2,
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 140
           },
-          "hiddenSeries": false,
           "id": 132,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_memory_NFS_Unstable_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_memory_NFS_Unstable_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "NFS Unstable - Memory in NFS pages sent to the server, but not yet commited to the storage",
@@ -6131,37 +5746,8 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Memory NFS",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "bytes",
-              "label": "bytes",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         }
       ],
       "title": "Memory Meminfo",
@@ -6169,10 +5755,6 @@
     },
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -6182,59 +5764,32 @@
       "id": 267,
       "panels": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 23
           },
-          "hiddenSeries": false,
           "id": 176,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "/.*out/",
-              "transform": "negative-Y"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_vmstat_pgpgin{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_vmstat_pgpgin{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Pagesin - Page in operations",
@@ -6242,7 +5797,11 @@
               "step": 240
             },
             {
-              "expr": "rate(node_vmstat_pgpgout{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_vmstat_pgpgout{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Pagesout - Page out operations",
@@ -6250,91 +5809,36 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Memory Pages In / Out",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "pages out (-) / in (+)",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 23
           },
-          "hiddenSeries": false,
           "id": 22,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "/.*out/",
-              "transform": "negative-Y"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_vmstat_pswpin{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_vmstat_pswpin{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Pswpin - Pages swapped in",
@@ -6342,7 +5846,11 @@
               "step": 240
             },
             {
-              "expr": "rate(node_vmstat_pswpout{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_vmstat_pswpout{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Pswpout - Pages swapped out",
@@ -6350,113 +5858,36 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Memory Pages Swap In / Out",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "pages out (-) / in (+)",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "Apps": "#629E51",
-            "Buffers": "#614D93",
-            "Cache": "#6D1F62",
-            "Cached": "#511749",
-            "Committed": "#508642",
-            "Free": "#0A437C",
-            "Hardware Corrupted - Amount of RAM that the kernel identified as corrupted / not working": "#CFFAFF",
-            "Inactive": "#584477",
-            "PageTables": "#0A50A1",
-            "Page_Tables": "#0A50A1",
-            "RAM_Free": "#E0F9D7",
-            "Slab": "#806EB7",
-            "Slab_Cache": "#E0752D",
-            "Swap": "#BF1B00",
-            "Swap_Cache": "#C15C17",
-            "Swap_Free": "#2F575E",
-            "Unused": "#EAB839"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "decimals": 2,
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 33
           },
-          "hiddenSeries": false,
           "id": 175,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": 350,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:6118",
-              "alias": "Pgfault - Page major and minor fault operations",
-              "fill": 0,
-              "stack": false
-            }
-          ],
-          "spaceLength": 10,
-          "stack": true,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_vmstat_pgfault{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_vmstat_pgfault{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Pgfault - Page major and minor fault operations",
@@ -6464,7 +5895,11 @@
               "step": 240
             },
             {
-              "expr": "rate(node_vmstat_pgmajfault{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_vmstat_pgmajfault{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Pgmajfault - Major page fault operations",
@@ -6472,7 +5907,11 @@
               "step": 240
             },
             {
-              "expr": "rate(node_vmstat_pgfault{supabase_project_ref=\"$project\"}[$__rate_interval])  - rate(node_vmstat_pgmajfault{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_vmstat_pgfault{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])  - rate(node_vmstat_pgmajfault{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Pgminfault - Minor page fault operations",
@@ -6480,110 +5919,36 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Memory Page Faults",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "cumulative"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:6133",
-              "format": "short",
-              "label": "faults",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:6134",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "Active": "#99440A",
-            "Buffers": "#58140C",
-            "Cache": "#6D1F62",
-            "Cached": "#511749",
-            "Committed": "#508642",
-            "Dirty": "#6ED0E0",
-            "Free": "#B7DBAB",
-            "Inactive": "#EA6460",
-            "Mapped": "#052B51",
-            "PageTables": "#0A50A1",
-            "Page_Tables": "#0A50A1",
-            "Slab_Cache": "#EAB839",
-            "Swap": "#BF1B00",
-            "Swap_Cache": "#C15C17",
-            "Total": "#511749",
-            "Total RAM": "#052B51",
-            "Total RAM + Swap": "#052B51",
-            "Total Swap": "#614D93",
-            "VmallocUsed": "#EA6460"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "decimals": 2,
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 33
           },
-          "hiddenSeries": false,
           "id": 307,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_vmstat_oom_kill{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_vmstat_oom_kill{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -6592,39 +5957,8 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "OOM Killer",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:5373",
-              "format": "short",
-              "label": "counter",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:5374",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         }
       ],
       "title": "Memory Vmstat",
@@ -6632,10 +5966,6 @@
     },
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -6645,58 +5975,32 @@
       "id": 293,
       "panels": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "description": "",
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 24
           },
-          "hiddenSeries": false,
           "id": 260,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "/.*Variation*./",
-              "color": "#890F02"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_timex_estimated_error_seconds{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_timex_estimated_error_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -6706,7 +6010,11 @@
               "step": 240
             },
             {
-              "expr": "node_timex_offset_seconds{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_timex_offset_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -6716,7 +6024,11 @@
               "step": 240
             },
             {
-              "expr": "node_timex_maxerror_seconds{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_timex_maxerror_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -6726,86 +6038,36 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Time Syncronized Drift",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "s",
-              "label": "seconds",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": "counter",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "description": "",
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 24
           },
-          "hiddenSeries": false,
           "id": 291,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_timex_loop_time_constant{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_timex_loop_time_constant{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -6814,90 +6076,36 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Time PLL Adjust",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "counter",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "description": "",
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 34
           },
-          "hiddenSeries": false,
           "id": 168,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "/.*Variation*./",
-              "color": "#890F02"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_timex_sync_status{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_timex_sync_status{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -6906,7 +6114,11 @@
               "step": 240
             },
             {
-              "expr": "node_timex_frequency_adjustment_ratio{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_timex_frequency_adjustment_ratio{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -6915,85 +6127,36 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Time Syncronized Status",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "counter",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "description": "",
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 34
           },
-          "hiddenSeries": false,
           "id": 294,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_timex_tick_seconds{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_timex_tick_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -7002,7 +6165,11 @@
               "step": 240
             },
             {
-              "expr": "node_timex_tai_offset_seconds{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_timex_tai_offset_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -7011,36 +6178,8 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Time Misc",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "s",
-              "label": "seconds",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         }
       ],
       "title": "System Timesync",
@@ -7048,10 +6187,6 @@
     },
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -7061,53 +6196,32 @@
       "id": 312,
       "panels": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 7
           },
-          "hiddenSeries": false,
           "id": 62,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_procs_blocked{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_procs_blocked{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Processes blocked waiting for I/O to complete",
@@ -7115,7 +6229,11 @@
               "step": 240
             },
             {
-              "expr": "node_procs_running{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_procs_running{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Processes in runnable state",
@@ -7123,88 +6241,36 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Processes Status",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:6500",
-              "format": "short",
-              "label": "counter",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:6501",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 7
           },
-          "hiddenSeries": false,
           "id": 315,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": true,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_processes_state{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_processes_state{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -7213,88 +6279,36 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Processes State",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:6500",
-              "format": "short",
-              "label": "counter",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:6501",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 17
           },
-          "hiddenSeries": false,
           "id": 148,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_forks_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_forks_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -7303,92 +6317,35 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Processes  Forks",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:6640",
-              "format": "short",
-              "label": "forks / sec",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:6641",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 17
           },
-          "hiddenSeries": false,
           "id": 149,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "/.*Max.*/",
-              "fill": 0
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(process_virtual_memory_bytes{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(process_virtual_memory_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
@@ -7397,7 +6354,11 @@
               "step": 240
             },
             {
-              "expr": "process_resident_memory_max_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "process_resident_memory_max_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
@@ -7406,7 +6367,11 @@
               "step": 240
             },
             {
-              "expr": "rate(process_virtual_memory_bytes{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(process_virtual_memory_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
@@ -7415,7 +6380,11 @@
               "step": 240
             },
             {
-              "expr": "rate(process_virtual_memory_max_bytes{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(process_virtual_memory_max_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
@@ -7424,93 +6393,36 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Processes Memory",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "decbytes",
-              "label": "bytes",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 27
           },
-          "hiddenSeries": false,
           "id": 313,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:709",
-              "alias": "PIDs limit",
-              "color": "#F2495C",
-              "fill": 0
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_processes_pids{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_processes_pids{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -7519,7 +6431,11 @@
               "step": 240
             },
             {
-              "expr": "node_processes_max_processes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_processes_max_processes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -7528,94 +6444,36 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "PIDs Number and Limit",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:6500",
-              "format": "short",
-              "label": "counter",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:6501",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 27
           },
-          "hiddenSeries": false,
           "id": 305,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:4963",
-              "alias": "/.*waiting.*/",
-              "transform": "negative-Y"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_schedstat_running_seconds_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_schedstat_running_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -7624,7 +6482,11 @@
               "step": 240
             },
             {
-              "expr": "rate(node_schedstat_waiting_seconds_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_schedstat_waiting_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -7633,94 +6495,36 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Process schedule stats Running / Waiting",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:4860",
-              "format": "s",
-              "label": "seconds",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:4861",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 37
           },
-          "hiddenSeries": false,
           "id": 314,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:709",
-              "alias": "Threads limit",
-              "color": "#F2495C",
-              "fill": 0
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_processes_threads{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_processes_threads{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -7729,7 +6533,11 @@
               "step": 240
             },
             {
-              "expr": "node_processes_max_threads{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_processes_max_threads{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -7738,39 +6546,8 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Threads Number and Limit",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:6500",
-              "format": "short",
-              "label": "counter",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:6501",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         }
       ],
       "title": "System Processes",
@@ -7778,10 +6555,6 @@
     },
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -7791,53 +6564,32 @@
       "id": 269,
       "panels": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 8
           },
-          "hiddenSeries": false,
           "id": 8,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_context_switches_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_context_switches_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Context switches",
@@ -7845,7 +6597,11 @@
               "step": 240
             },
             {
-              "expr": "rate(node_intr_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_intr_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -7854,86 +6610,36 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Context Switches / Interrupts",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "counter",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 8
           },
-          "hiddenSeries": false,
           "id": 7,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_load1{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_load1{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Load 1m",
@@ -7941,7 +6647,11 @@
               "step": 240
             },
             {
-              "expr": "node_load5{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_load5{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Load 5m",
@@ -7949,7 +6659,11 @@
               "step": 240
             },
             {
-              "expr": "node_load15{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_load15{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Load 15m",
@@ -7957,98 +6671,35 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "System Load",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:6261",
-              "format": "short",
-              "label": "counter",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:6262",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 18
           },
-          "hiddenSeries": false,
           "id": 259,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "/.*Critical*./",
-              "color": "#E24D42",
-              "fill": 0
-            },
-            {
-              "alias": "/.*Max*./",
-              "color": "#EF843C",
-              "fill": 0
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_interrupts_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_interrupts_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -8057,86 +6708,36 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Interrupts Detail",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "counter",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 18
           },
-          "hiddenSeries": false,
           "id": 306,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_schedstat_timeslices_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_schedstat_timeslices_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -8145,87 +6746,36 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Schedule timeslices executed by each cpu",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:4860",
-              "format": "short",
-              "label": "counter",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:4861",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 28
           },
-          "hiddenSeries": false,
           "id": 151,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_entropy_available_bits{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_entropy_available_bits{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Entropy available to random number generators",
@@ -8233,88 +6783,36 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Entropy",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:6568",
-              "format": "short",
-              "label": "counter",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:6569",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 28
           },
-          "hiddenSeries": false,
           "id": 308,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(process_cpu_seconds_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(process_cpu_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -8323,93 +6821,35 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "CPU time spent in user and system contexts",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:4860",
-              "format": "s",
-              "label": "seconds",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:4861",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 38
           },
-          "hiddenSeries": false,
           "id": 64,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:6323",
-              "alias": "/.*Max*./",
-              "color": "#890F02",
-              "fill": 0
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "process_max_fds{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "process_max_fds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "interval": "",
               "intervalFactor": 1,
               "legendFormat": "Maximum open file descriptors",
@@ -8417,7 +6857,11 @@
               "step": 240
             },
             {
-              "expr": "process_open_fds{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "process_open_fds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "interval": "",
               "intervalFactor": 1,
               "legendFormat": "Open file descriptors",
@@ -8425,39 +6869,8 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "File Descriptors",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:6338",
-              "format": "short",
-              "label": "counter",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:6339",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         }
       ],
       "title": "System Misc",
@@ -8465,10 +6878,6 @@
     },
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -8478,65 +6887,31 @@
       "id": 304,
       "panels": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 26
           },
-          "hiddenSeries": false,
           "id": 158,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:6726",
-              "alias": "/.*Critical*./",
-              "color": "#E24D42",
-              "fill": 0
-            },
-            {
-              "$$hashKey": "object:6727",
-              "alias": "/.*Max*./",
-              "color": "#EF843C",
-              "fill": 0
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_hwmon_temp_celsius{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_hwmon_temp_celsius{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -8545,7 +6920,11 @@
               "step": 240
             },
             {
-              "expr": "node_hwmon_temp_crit_alarm_celsius{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_hwmon_temp_crit_alarm_celsius{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "hide": true,
               "interval": "",
@@ -8555,7 +6934,11 @@
               "step": 240
             },
             {
-              "expr": "node_hwmon_temp_crit_celsius{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_hwmon_temp_crit_celsius{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -8564,7 +6947,11 @@
               "step": 240
             },
             {
-              "expr": "node_hwmon_temp_crit_hyst_celsius{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_hwmon_temp_crit_hyst_celsius{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "hide": true,
               "interval": "",
@@ -8574,7 +6961,11 @@
               "step": 240
             },
             {
-              "expr": "node_hwmon_temp_max_celsius{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_hwmon_temp_max_celsius{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "hide": true,
               "interval": "",
@@ -8584,94 +6975,35 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Hardware temperature monitor",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:6750",
-              "format": "celsius",
-              "label": "temperature",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:6751",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 26
           },
-          "hiddenSeries": false,
           "id": 300,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:1655",
-              "alias": "/.*Max*./",
-              "color": "#EF843C",
-              "fill": 0
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_cooling_device_cur_state{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_cooling_device_cur_state{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -8681,7 +7013,11 @@
               "step": 240
             },
             {
-              "expr": "node_cooling_device_max_state{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_cooling_device_max_state{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -8690,86 +7026,35 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Throttle cooling device",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:1678",
-              "format": "short",
-              "label": "counter",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:1679",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 36
           },
-          "hiddenSeries": false,
           "id": 302,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_power_supply_online{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_power_supply_online{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -8779,38 +7064,8 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Power supply",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:1678",
-              "format": "short",
-              "label": "counter",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:1679",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         }
       ],
       "title": "Hardware Misc",
@@ -8818,10 +7073,6 @@
     },
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -8831,52 +7082,31 @@
       "id": 296,
       "panels": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 10
           },
-          "hiddenSeries": false,
           "id": 297,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_systemd_socket_accepted_connections_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_systemd_socket_accepted_connections_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -8885,106 +7115,35 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Systemd Sockets",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "counter",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 10
           },
-          "hiddenSeries": false,
           "id": 298,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "Failed",
-              "color": "#F2495C"
-            },
-            {
-              "alias": "Inactive",
-              "color": "#FF9830"
-            },
-            {
-              "alias": "Active",
-              "color": "#73BF69"
-            },
-            {
-              "alias": "Deactivating",
-              "color": "#FFCB7D"
-            },
-            {
-              "alias": "Activating",
-              "color": "#C8F2C2"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": true,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_systemd_units{supabase_project_ref=\"$project\",state=\"activating\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_systemd_units{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",state=\"activating\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -8993,7 +7152,11 @@
               "step": 240
             },
             {
-              "expr": "node_systemd_units{supabase_project_ref=\"$project\",state=\"active\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_systemd_units{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",state=\"active\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -9002,7 +7165,11 @@
               "step": 240
             },
             {
-              "expr": "node_systemd_units{supabase_project_ref=\"$project\",state=\"deactivating\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_systemd_units{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",state=\"deactivating\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -9011,7 +7178,11 @@
               "step": 240
             },
             {
-              "expr": "node_systemd_units{supabase_project_ref=\"$project\",state=\"failed\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_systemd_units{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",state=\"failed\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -9020,7 +7191,11 @@
               "step": 240
             },
             {
-              "expr": "node_systemd_units{supabase_project_ref=\"$project\",state=\"inactive\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_systemd_units{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",state=\"inactive\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -9029,36 +7204,8 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Systemd Units State",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "counter",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         }
       ],
       "title": "Systemd",
@@ -9066,10 +7213,6 @@
     },
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -9079,13 +7222,9 @@
       "id": 270,
       "panels": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "description": "The number (after merges) of I/O requests completed per second for the device",
           "fieldConfig": {
@@ -9095,208 +7234,49 @@
             },
             "overrides": []
           },
-          "fill": 2,
-          "fillGradient": 0,
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 11
           },
-          "hiddenSeries": false,
           "id": 9,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideZero": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:2033",
-              "alias": "/.*Read.*/",
-              "transform": "negative-Y"
-            },
-            {
-              "$$hashKey": "object:2034",
-              "alias": "/.*sda_.*/",
-              "color": "#7EB26D"
-            },
-            {
-              "$$hashKey": "object:2035",
-              "alias": "/.*sdb_.*/",
-              "color": "#EAB839"
-            },
-            {
-              "$$hashKey": "object:2036",
-              "alias": "/.*sdc_.*/",
-              "color": "#6ED0E0"
-            },
-            {
-              "$$hashKey": "object:2037",
-              "alias": "/.*sdd_.*/",
-              "color": "#EF843C"
-            },
-            {
-              "$$hashKey": "object:2038",
-              "alias": "/.*sde_.*/",
-              "color": "#E24D42"
-            },
-            {
-              "$$hashKey": "object:2039",
-              "alias": "/.*sda1.*/",
-              "color": "#584477"
-            },
-            {
-              "$$hashKey": "object:2040",
-              "alias": "/.*sda2_.*/",
-              "color": "#BA43A9"
-            },
-            {
-              "$$hashKey": "object:2041",
-              "alias": "/.*sda3_.*/",
-              "color": "#F4D598"
-            },
-            {
-              "$$hashKey": "object:2042",
-              "alias": "/.*sdb1.*/",
-              "color": "#0A50A1"
-            },
-            {
-              "$$hashKey": "object:2043",
-              "alias": "/.*sdb2.*/",
-              "color": "#BF1B00"
-            },
-            {
-              "$$hashKey": "object:2044",
-              "alias": "/.*sdb3.*/",
-              "color": "#E0752D"
-            },
-            {
-              "$$hashKey": "object:2045",
-              "alias": "/.*sdc1.*/",
-              "color": "#962D82"
-            },
-            {
-              "$$hashKey": "object:2046",
-              "alias": "/.*sdc2.*/",
-              "color": "#614D93"
-            },
-            {
-              "$$hashKey": "object:2047",
-              "alias": "/.*sdc3.*/",
-              "color": "#9AC48A"
-            },
-            {
-              "$$hashKey": "object:2048",
-              "alias": "/.*sdd1.*/",
-              "color": "#65C5DB"
-            },
-            {
-              "$$hashKey": "object:2049",
-              "alias": "/.*sdd2.*/",
-              "color": "#F9934E"
-            },
-            {
-              "$$hashKey": "object:2050",
-              "alias": "/.*sdd3.*/",
-              "color": "#EA6460"
-            },
-            {
-              "$$hashKey": "object:2051",
-              "alias": "/.*sde1.*/",
-              "color": "#E0F9D7"
-            },
-            {
-              "$$hashKey": "object:2052",
-              "alias": "/.*sdd2.*/",
-              "color": "#FCEACA"
-            },
-            {
-              "$$hashKey": "object:2053",
-              "alias": "/.*sde3.*/",
-              "color": "#F9E2D2"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_disk_reads_completed_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_disk_reads_completed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "intervalFactor": 1,
               "legendFormat": "{{device}} - Reads completed",
               "refId": "A",
               "step": 240
             },
             {
-              "expr": "rate(node_disk_writes_completed_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_disk_writes_completed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "intervalFactor": 1,
               "legendFormat": "{{device}} - Writes completed",
               "refId": "B",
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Disk IOps Completed",
-          "tooltip": {
-            "shared": false,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:2186",
-              "format": "iops",
-              "label": "IO read (-) / write (+)",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:2187",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "description": "The number of bytes read from or written to the device per second",
           "fieldConfig": {
@@ -9306,133 +7286,25 @@
             },
             "overrides": []
           },
-          "fill": 2,
-          "fillGradient": 0,
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 11
           },
-          "hiddenSeries": false,
           "id": 33,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideZero": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "/.*Read.*/",
-              "transform": "negative-Y"
-            },
-            {
-              "alias": "/.*sda_.*/",
-              "color": "#7EB26D"
-            },
-            {
-              "alias": "/.*sdb_.*/",
-              "color": "#EAB839"
-            },
-            {
-              "alias": "/.*sdc_.*/",
-              "color": "#6ED0E0"
-            },
-            {
-              "alias": "/.*sdd_.*/",
-              "color": "#EF843C"
-            },
-            {
-              "alias": "/.*sde_.*/",
-              "color": "#E24D42"
-            },
-            {
-              "alias": "/.*sda1.*/",
-              "color": "#584477"
-            },
-            {
-              "alias": "/.*sda2_.*/",
-              "color": "#BA43A9"
-            },
-            {
-              "alias": "/.*sda3_.*/",
-              "color": "#F4D598"
-            },
-            {
-              "alias": "/.*sdb1.*/",
-              "color": "#0A50A1"
-            },
-            {
-              "alias": "/.*sdb2.*/",
-              "color": "#BF1B00"
-            },
-            {
-              "alias": "/.*sdb3.*/",
-              "color": "#E0752D"
-            },
-            {
-              "alias": "/.*sdc1.*/",
-              "color": "#962D82"
-            },
-            {
-              "alias": "/.*sdc2.*/",
-              "color": "#614D93"
-            },
-            {
-              "alias": "/.*sdc3.*/",
-              "color": "#9AC48A"
-            },
-            {
-              "alias": "/.*sdd1.*/",
-              "color": "#65C5DB"
-            },
-            {
-              "alias": "/.*sdd2.*/",
-              "color": "#F9934E"
-            },
-            {
-              "alias": "/.*sdd3.*/",
-              "color": "#EA6460"
-            },
-            {
-              "alias": "/.*sde1.*/",
-              "color": "#E0F9D7"
-            },
-            {
-              "alias": "/.*sdd2.*/",
-              "color": "#FCEACA"
-            },
-            {
-              "alias": "/.*sde3.*/",
-              "color": "#F9E2D2"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_disk_read_bytes_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_disk_read_bytes_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{device}} - Read bytes",
@@ -9440,7 +7312,11 @@
               "step": 240
             },
             {
-              "expr": "rate(node_disk_written_bytes_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_disk_written_bytes_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{device}} - Written bytes",
@@ -9448,47 +7324,13 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Disk R/W Data",
-          "tooltip": {
-            "shared": false,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:369",
-              "format": "Bps",
-              "label": "bytes read (-) / write (+)",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:370",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "description": "The average time for requests issued to the device to be served. This includes the time spent by the requests in queue and the time spent servicing them.",
           "fieldConfig": {
@@ -9498,135 +7340,25 @@
             },
             "overrides": []
           },
-          "fill": 3,
-          "fillGradient": 0,
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 21
           },
-          "hiddenSeries": false,
           "id": 37,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideZero": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "/.*Read.*/",
-              "transform": "negative-Y"
-            },
-            {
-              "alias": "/.*sda_.*/",
-              "color": "#7EB26D"
-            },
-            {
-              "alias": "/.*sdb_.*/",
-              "color": "#EAB839"
-            },
-            {
-              "alias": "/.*sdc_.*/",
-              "color": "#6ED0E0"
-            },
-            {
-              "alias": "/.*sdd_.*/",
-              "color": "#EF843C"
-            },
-            {
-              "alias": "/.*sde_.*/",
-              "color": "#E24D42"
-            },
-            {
-              "alias": "/.*sda1.*/",
-              "color": "#584477"
-            },
-            {
-              "alias": "/.*sda2_.*/",
-              "color": "#BA43A9"
-            },
-            {
-              "alias": "/.*sda3_.*/",
-              "color": "#F4D598"
-            },
-            {
-              "alias": "/.*sdb1.*/",
-              "color": "#0A50A1"
-            },
-            {
-              "alias": "/.*sdb2.*/",
-              "color": "#BF1B00"
-            },
-            {
-              "alias": "/.*sdb3.*/",
-              "color": "#E0752D"
-            },
-            {
-              "alias": "/.*sdc1.*/",
-              "color": "#962D82"
-            },
-            {
-              "alias": "/.*sdc2.*/",
-              "color": "#614D93"
-            },
-            {
-              "alias": "/.*sdc3.*/",
-              "color": "#9AC48A"
-            },
-            {
-              "alias": "/.*sdd1.*/",
-              "color": "#65C5DB"
-            },
-            {
-              "alias": "/.*sdd2.*/",
-              "color": "#F9934E"
-            },
-            {
-              "alias": "/.*sdd3.*/",
-              "color": "#EA6460"
-            },
-            {
-              "alias": "/.*sde1.*/",
-              "color": "#E0F9D7"
-            },
-            {
-              "alias": "/.*sdd2.*/",
-              "color": "#FCEACA"
-            },
-            {
-              "alias": "/.*sde3.*/",
-              "color": "#F9E2D2"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_disk_read_time_seconds_total{supabase_project_ref=\"$project\"}[$__rate_interval]) / rate(node_disk_reads_completed_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_disk_read_time_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval]) / rate(node_disk_reads_completed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "hide": false,
               "interval": "",
               "intervalFactor": 4,
@@ -9635,7 +7367,11 @@
               "step": 240
             },
             {
-              "expr": "rate(node_disk_write_time_seconds_total{supabase_project_ref=\"$project\"}[$__rate_interval]) / rate(node_disk_writes_completed_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_disk_write_time_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval]) / rate(node_disk_writes_completed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
@@ -9644,47 +7380,13 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Disk Average Wait Time",
-          "tooltip": {
-            "shared": false,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:441",
-              "format": "s",
-              "label": "time. read (-) / write (+)",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:442",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "description": "The average queue length of the requests that were issued to the device",
           "fieldConfig": {
@@ -9694,131 +7396,25 @@
             },
             "overrides": []
           },
-          "fill": 2,
-          "fillGradient": 0,
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 21
           },
-          "hiddenSeries": false,
           "id": 35,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideZero": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "/.*sda_.*/",
-              "color": "#7EB26D"
-            },
-            {
-              "alias": "/.*sdb_.*/",
-              "color": "#EAB839"
-            },
-            {
-              "alias": "/.*sdc_.*/",
-              "color": "#6ED0E0"
-            },
-            {
-              "alias": "/.*sdd_.*/",
-              "color": "#EF843C"
-            },
-            {
-              "alias": "/.*sde_.*/",
-              "color": "#E24D42"
-            },
-            {
-              "alias": "/.*sda1.*/",
-              "color": "#584477"
-            },
-            {
-              "alias": "/.*sda2_.*/",
-              "color": "#BA43A9"
-            },
-            {
-              "alias": "/.*sda3_.*/",
-              "color": "#F4D598"
-            },
-            {
-              "alias": "/.*sdb1.*/",
-              "color": "#0A50A1"
-            },
-            {
-              "alias": "/.*sdb2.*/",
-              "color": "#BF1B00"
-            },
-            {
-              "alias": "/.*sdb3.*/",
-              "color": "#E0752D"
-            },
-            {
-              "alias": "/.*sdc1.*/",
-              "color": "#962D82"
-            },
-            {
-              "alias": "/.*sdc2.*/",
-              "color": "#614D93"
-            },
-            {
-              "alias": "/.*sdc3.*/",
-              "color": "#9AC48A"
-            },
-            {
-              "alias": "/.*sdd1.*/",
-              "color": "#65C5DB"
-            },
-            {
-              "alias": "/.*sdd2.*/",
-              "color": "#F9934E"
-            },
-            {
-              "alias": "/.*sdd3.*/",
-              "color": "#EA6460"
-            },
-            {
-              "alias": "/.*sde1.*/",
-              "color": "#E0F9D7"
-            },
-            {
-              "alias": "/.*sdd2.*/",
-              "color": "#FCEACA"
-            },
-            {
-              "alias": "/.*sde3.*/",
-              "color": "#F9E2D2"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_disk_io_time_weighted_seconds_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_disk_io_time_weighted_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "interval": "",
               "intervalFactor": 1,
               "legendFormat": "{{device}}",
@@ -9826,48 +7422,13 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Average Queue Size",
-          "tooltip": {
-            "shared": false,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:513",
-              "format": "none",
-              "label": "aqu-sz",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:514",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "description": "The number of read and write requests merged per second that were queued to the device",
           "fieldConfig": {
@@ -9877,189 +7438,49 @@
             },
             "overrides": []
           },
-          "fill": 2,
-          "fillGradient": 0,
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 31
           },
-          "hiddenSeries": false,
           "id": 133,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideZero": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "/.*Read.*/",
-              "transform": "negative-Y"
-            },
-            {
-              "alias": "/.*sda_.*/",
-              "color": "#7EB26D"
-            },
-            {
-              "alias": "/.*sdb_.*/",
-              "color": "#EAB839"
-            },
-            {
-              "alias": "/.*sdc_.*/",
-              "color": "#6ED0E0"
-            },
-            {
-              "alias": "/.*sdd_.*/",
-              "color": "#EF843C"
-            },
-            {
-              "alias": "/.*sde_.*/",
-              "color": "#E24D42"
-            },
-            {
-              "alias": "/.*sda1.*/",
-              "color": "#584477"
-            },
-            {
-              "alias": "/.*sda2_.*/",
-              "color": "#BA43A9"
-            },
-            {
-              "alias": "/.*sda3_.*/",
-              "color": "#F4D598"
-            },
-            {
-              "alias": "/.*sdb1.*/",
-              "color": "#0A50A1"
-            },
-            {
-              "alias": "/.*sdb2.*/",
-              "color": "#BF1B00"
-            },
-            {
-              "alias": "/.*sdb3.*/",
-              "color": "#E0752D"
-            },
-            {
-              "alias": "/.*sdc1.*/",
-              "color": "#962D82"
-            },
-            {
-              "alias": "/.*sdc2.*/",
-              "color": "#614D93"
-            },
-            {
-              "alias": "/.*sdc3.*/",
-              "color": "#9AC48A"
-            },
-            {
-              "alias": "/.*sdd1.*/",
-              "color": "#65C5DB"
-            },
-            {
-              "alias": "/.*sdd2.*/",
-              "color": "#F9934E"
-            },
-            {
-              "alias": "/.*sdd3.*/",
-              "color": "#EA6460"
-            },
-            {
-              "alias": "/.*sde1.*/",
-              "color": "#E0F9D7"
-            },
-            {
-              "alias": "/.*sdd2.*/",
-              "color": "#FCEACA"
-            },
-            {
-              "alias": "/.*sde3.*/",
-              "color": "#F9E2D2"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_disk_reads_merged_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_disk_reads_merged_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "intervalFactor": 1,
               "legendFormat": "{{device}} - Read merged",
               "refId": "A",
               "step": 240
             },
             {
-              "expr": "rate(node_disk_writes_merged_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_disk_writes_merged_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "intervalFactor": 1,
               "legendFormat": "{{device}} - Write merged",
               "refId": "B",
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Disk R/W Merged",
-          "tooltip": {
-            "shared": false,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:585",
-              "format": "iops",
-              "label": "I/Os",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:586",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "description": "Percentage of elapsed time during which I/O requests were issued to the device (bandwidth utilization for the device). Device saturation occurs when this value is close to 100% for devices serving requests serially.  But for devices  serving requests in parallel, such as RAID arrays and modern SSDs, this number does not reflect their performance limits.",
           "fieldConfig": {
@@ -10069,131 +7490,25 @@
             },
             "overrides": []
           },
-          "fill": 3,
-          "fillGradient": 0,
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 31
           },
-          "hiddenSeries": false,
           "id": 36,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideZero": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "/.*sda_.*/",
-              "color": "#7EB26D"
-            },
-            {
-              "alias": "/.*sdb_.*/",
-              "color": "#EAB839"
-            },
-            {
-              "alias": "/.*sdc_.*/",
-              "color": "#6ED0E0"
-            },
-            {
-              "alias": "/.*sdd_.*/",
-              "color": "#EF843C"
-            },
-            {
-              "alias": "/.*sde_.*/",
-              "color": "#E24D42"
-            },
-            {
-              "alias": "/.*sda1.*/",
-              "color": "#584477"
-            },
-            {
-              "alias": "/.*sda2_.*/",
-              "color": "#BA43A9"
-            },
-            {
-              "alias": "/.*sda3_.*/",
-              "color": "#F4D598"
-            },
-            {
-              "alias": "/.*sdb1.*/",
-              "color": "#0A50A1"
-            },
-            {
-              "alias": "/.*sdb2.*/",
-              "color": "#BF1B00"
-            },
-            {
-              "alias": "/.*sdb3.*/",
-              "color": "#E0752D"
-            },
-            {
-              "alias": "/.*sdc1.*/",
-              "color": "#962D82"
-            },
-            {
-              "alias": "/.*sdc2.*/",
-              "color": "#614D93"
-            },
-            {
-              "alias": "/.*sdc3.*/",
-              "color": "#9AC48A"
-            },
-            {
-              "alias": "/.*sdd1.*/",
-              "color": "#65C5DB"
-            },
-            {
-              "alias": "/.*sdd2.*/",
-              "color": "#F9934E"
-            },
-            {
-              "alias": "/.*sdd3.*/",
-              "color": "#EA6460"
-            },
-            {
-              "alias": "/.*sde1.*/",
-              "color": "#E0F9D7"
-            },
-            {
-              "alias": "/.*sdd2.*/",
-              "color": "#FCEACA"
-            },
-            {
-              "alias": "/.*sde3.*/",
-              "color": "#F9E2D2"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_disk_io_time_seconds_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_disk_io_time_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "interval": "",
               "intervalFactor": 1,
               "legendFormat": "{{device}} - IO",
@@ -10201,7 +7516,11 @@
               "step": 240
             },
             {
-              "expr": "rate(node_disk_discard_time_seconds_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_disk_discard_time_seconds_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "interval": "",
               "intervalFactor": 1,
               "legendFormat": "{{device}} - discard",
@@ -10209,48 +7528,13 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Time Spent Doing I/Os",
-          "tooltip": {
-            "shared": false,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:657",
-              "format": "percentunit",
-              "label": "%util",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:658",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "description": "The number of outstanding requests at the instant the sample was taken. Incremented as requests are given to appropriate struct request_queue and decremented as they finish.",
           "fieldConfig": {
@@ -10260,131 +7544,25 @@
             },
             "overrides": []
           },
-          "fill": 2,
-          "fillGradient": 0,
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 41
           },
-          "hiddenSeries": false,
           "id": 34,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideZero": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "/.*sda_.*/",
-              "color": "#7EB26D"
-            },
-            {
-              "alias": "/.*sdb_.*/",
-              "color": "#EAB839"
-            },
-            {
-              "alias": "/.*sdc_.*/",
-              "color": "#6ED0E0"
-            },
-            {
-              "alias": "/.*sdd_.*/",
-              "color": "#EF843C"
-            },
-            {
-              "alias": "/.*sde_.*/",
-              "color": "#E24D42"
-            },
-            {
-              "alias": "/.*sda1.*/",
-              "color": "#584477"
-            },
-            {
-              "alias": "/.*sda2_.*/",
-              "color": "#BA43A9"
-            },
-            {
-              "alias": "/.*sda3_.*/",
-              "color": "#F4D598"
-            },
-            {
-              "alias": "/.*sdb1.*/",
-              "color": "#0A50A1"
-            },
-            {
-              "alias": "/.*sdb2.*/",
-              "color": "#BF1B00"
-            },
-            {
-              "alias": "/.*sdb3.*/",
-              "color": "#E0752D"
-            },
-            {
-              "alias": "/.*sdc1.*/",
-              "color": "#962D82"
-            },
-            {
-              "alias": "/.*sdc2.*/",
-              "color": "#614D93"
-            },
-            {
-              "alias": "/.*sdc3.*/",
-              "color": "#9AC48A"
-            },
-            {
-              "alias": "/.*sdd1.*/",
-              "color": "#65C5DB"
-            },
-            {
-              "alias": "/.*sdd2.*/",
-              "color": "#F9934E"
-            },
-            {
-              "alias": "/.*sdd3.*/",
-              "color": "#EA6460"
-            },
-            {
-              "alias": "/.*sde1.*/",
-              "color": "#E0F9D7"
-            },
-            {
-              "alias": "/.*sdd2.*/",
-              "color": "#FCEACA"
-            },
-            {
-              "alias": "/.*sde3.*/",
-              "color": "#F9E2D2"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_disk_io_now{supabase_project_ref=\"$project\"})",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_disk_io_now{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"})",
               "interval": "",
               "intervalFactor": 4,
               "legendFormat": "{{device}} - IO now",
@@ -10392,48 +7570,13 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Instantaneous Queue Size",
-          "tooltip": {
-            "shared": false,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:729",
-              "format": "none",
-              "label": "Outstanding req.",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:730",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "description": "",
           "fieldConfig": {
@@ -10443,149 +7586,25 @@
             },
             "overrides": []
           },
-          "fill": 2,
-          "fillGradient": 0,
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 41
           },
-          "hiddenSeries": false,
           "id": 301,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideZero": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null as zero",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:2034",
-              "alias": "/.*sda_.*/",
-              "color": "#7EB26D"
-            },
-            {
-              "$$hashKey": "object:2035",
-              "alias": "/.*sdb_.*/",
-              "color": "#EAB839"
-            },
-            {
-              "$$hashKey": "object:2036",
-              "alias": "/.*sdc_.*/",
-              "color": "#6ED0E0"
-            },
-            {
-              "$$hashKey": "object:2037",
-              "alias": "/.*sdd_.*/",
-              "color": "#EF843C"
-            },
-            {
-              "$$hashKey": "object:2038",
-              "alias": "/.*sde_.*/",
-              "color": "#E24D42"
-            },
-            {
-              "$$hashKey": "object:2039",
-              "alias": "/.*sda1.*/",
-              "color": "#584477"
-            },
-            {
-              "$$hashKey": "object:2040",
-              "alias": "/.*sda2_.*/",
-              "color": "#BA43A9"
-            },
-            {
-              "$$hashKey": "object:2041",
-              "alias": "/.*sda3_.*/",
-              "color": "#F4D598"
-            },
-            {
-              "$$hashKey": "object:2042",
-              "alias": "/.*sdb1.*/",
-              "color": "#0A50A1"
-            },
-            {
-              "$$hashKey": "object:2043",
-              "alias": "/.*sdb2.*/",
-              "color": "#BF1B00"
-            },
-            {
-              "$$hashKey": "object:2044",
-              "alias": "/.*sdb3.*/",
-              "color": "#E0752D"
-            },
-            {
-              "$$hashKey": "object:2045",
-              "alias": "/.*sdc1.*/",
-              "color": "#962D82"
-            },
-            {
-              "$$hashKey": "object:2046",
-              "alias": "/.*sdc2.*/",
-              "color": "#614D93"
-            },
-            {
-              "$$hashKey": "object:2047",
-              "alias": "/.*sdc3.*/",
-              "color": "#9AC48A"
-            },
-            {
-              "$$hashKey": "object:2048",
-              "alias": "/.*sdd1.*/",
-              "color": "#65C5DB"
-            },
-            {
-              "$$hashKey": "object:2049",
-              "alias": "/.*sdd2.*/",
-              "color": "#F9934E"
-            },
-            {
-              "$$hashKey": "object:2050",
-              "alias": "/.*sdd3.*/",
-              "color": "#EA6460"
-            },
-            {
-              "$$hashKey": "object:2051",
-              "alias": "/.*sde1.*/",
-              "color": "#E0F9D7"
-            },
-            {
-              "$$hashKey": "object:2052",
-              "alias": "/.*sdd2.*/",
-              "color": "#FCEACA"
-            },
-            {
-              "$$hashKey": "object:2053",
-              "alias": "/.*sde3.*/",
-              "color": "#F9E2D2"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_disk_discards_completed_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_disk_discards_completed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "interval": "",
               "intervalFactor": 1,
               "legendFormat": "{{device}} - Discards completed",
@@ -10593,7 +7612,11 @@
               "step": 240
             },
             {
-              "expr": "rate(node_disk_discards_merged_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_disk_discards_merged_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "interval": "",
               "intervalFactor": 1,
               "legendFormat": "{{device}} - Discards merged",
@@ -10601,38 +7624,8 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Disk IOps Discards completed / merged",
-          "tooltip": {
-            "shared": false,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:2186",
-              "format": "iops",
-              "label": "IOs",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:2187",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         }
       ],
       "title": "Storage Disk",
@@ -10640,10 +7633,6 @@
     },
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -10653,15 +7642,10 @@
       "id": 271,
       "panels": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "decimals": 3,
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -10670,47 +7654,25 @@
             },
             "overrides": []
           },
-          "fill": 2,
-          "fillGradient": 0,
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 12
           },
-          "hiddenSeries": false,
           "id": 43,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_filesystem_avail_bytes{supabase_project_ref=\"$project\",device!~'rootfs'}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_filesystem_avail_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'}",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -10720,7 +7682,11 @@
               "step": 240
             },
             {
-              "expr": "node_filesystem_free_bytes{supabase_project_ref=\"$project\",device!~'rootfs'}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_filesystem_free_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'}",
               "format": "time_series",
               "hide": true,
               "intervalFactor": 1,
@@ -10729,7 +7695,11 @@
               "step": 240
             },
             {
-              "expr": "node_filesystem_size_bytes{supabase_project_ref=\"$project\",device!~'rootfs'}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_filesystem_size_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'}",
               "format": "time_series",
               "hide": true,
               "intervalFactor": 1,
@@ -10738,48 +7708,13 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Filesystem space available",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:3826",
-              "format": "bytes",
-              "label": "bytes",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:3827",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "description": "",
           "fieldConfig": {
@@ -10789,47 +7724,24 @@
             },
             "overrides": []
           },
-          "fill": 2,
-          "fillGradient": 0,
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 12
           },
-          "hiddenSeries": false,
           "id": 41,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideZero": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_filesystem_files_free{supabase_project_ref=\"$project\",device!~'rootfs'}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_filesystem_files_free{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'}",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -10838,48 +7750,13 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "File Nodes Free",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:3894",
-              "format": "short",
-              "label": "file nodes",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:3895",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "description": "",
           "fieldConfig": {
@@ -10889,46 +7766,25 @@
             },
             "overrides": []
           },
-          "fill": 2,
-          "fillGradient": 0,
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 22
           },
-          "hiddenSeries": false,
           "id": 28,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_filefd_maximum{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_filefd_maximum{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Max open files",
@@ -10936,7 +7792,11 @@
               "step": 240
             },
             {
-              "expr": "node_filefd_allocated{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_filefd_allocated{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Open files",
@@ -10944,46 +7804,13 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "File Descriptor",
-          "tooltip": {
-            "shared": false,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "files",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "description": "",
           "fieldConfig": {
@@ -10993,47 +7820,24 @@
             },
             "overrides": []
           },
-          "fill": 2,
-          "fillGradient": 0,
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 22
           },
-          "hiddenSeries": false,
           "id": 219,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideZero": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_filesystem_files{supabase_project_ref=\"$project\",device!~'rootfs'}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_filesystem_files{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'}",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -11042,48 +7846,13 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "File Nodes Size",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "file Nodes",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "/ ReadOnly": "#890F02"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "description": "",
           "fieldConfig": {
@@ -11093,49 +7862,25 @@
             },
             "overrides": []
           },
-          "fill": 2,
-          "fillGradient": 0,
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 32
           },
-          "hiddenSeries": false,
           "id": 44,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideEmpty": true,
-            "hideZero": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 6,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": true,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_filesystem_readonly{supabase_project_ref=\"$project\",device!~'rootfs'}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_filesystem_readonly{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs'}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{mountpoint}} - ReadOnly",
@@ -11143,7 +7888,11 @@
               "step": 240
             },
             {
-              "expr": "node_filesystem_device_error{supabase_project_ref=\"$project\",device!~'rootfs',fstype!~'tmpfs'}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_filesystem_device_error{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\",device!~'rootfs',fstype!~'tmpfs'}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -11152,40 +7901,8 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Filesystem in ReadOnly / Error",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:3670",
-              "format": "short",
-              "label": "counter",
-              "logBase": 1,
-              "max": "1",
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:3671",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         }
       ],
       "title": "Storage Filesystem",
@@ -11193,10 +7910,6 @@
     },
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -11206,64 +7919,31 @@
       "id": 272,
       "panels": [
         {
-          "aliasColors": {
-            "receive_packets_eth0": "#7EB26D",
-            "receive_packets_lo": "#E24D42",
-            "transmit_packets_eth0": "#7EB26D",
-            "transmit_packets_lo": "#E24D42"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 30
           },
-          "hiddenSeries": false,
           "id": 60,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": 300,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "/.*Trans.*/",
-              "transform": "negative-Y"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_network_receive_packets_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_network_receive_packets_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -11272,7 +7952,11 @@
               "step": 240
             },
             {
-              "expr": "rate(node_network_transmit_packets_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_network_transmit_packets_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -11281,95 +7965,35 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Network Traffic by Packets",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "pps",
-              "label": "packets out (-) / in (+)",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 30
           },
-          "hiddenSeries": false,
           "id": 142,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": 300,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "/.*Trans.*/",
-              "transform": "negative-Y"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_network_receive_errs_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_network_receive_errs_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{device}} - Receive errors",
@@ -11377,7 +8001,11 @@
               "step": 240
             },
             {
-              "expr": "rate(node_network_transmit_errs_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_network_transmit_errs_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{device}} - Rransmit errors",
@@ -11385,95 +8013,35 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Network Traffic Errors",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "pps",
-              "label": "packets out (-) / in (+)",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 40
           },
-          "hiddenSeries": false,
           "id": 143,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": 300,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "/.*Trans.*/",
-              "transform": "negative-Y"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_network_receive_drop_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_network_receive_drop_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{device}} - Receive drop",
@@ -11481,7 +8049,11 @@
               "step": 240
             },
             {
-              "expr": "rate(node_network_transmit_drop_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_network_transmit_drop_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{device}} - Transmit drop",
@@ -11489,95 +8061,35 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Network Traffic Drop",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "pps",
-              "label": "packets out (-) / in (+)",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 40
           },
-          "hiddenSeries": false,
           "id": 141,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": 300,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "/.*Trans.*/",
-              "transform": "negative-Y"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_network_receive_compressed_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_network_receive_compressed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{device}} - Receive compressed",
@@ -11585,7 +8097,11 @@
               "step": 240
             },
             {
-              "expr": "rate(node_network_transmit_compressed_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_network_transmit_compressed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{device}} - Transmit compressed",
@@ -11593,95 +8109,35 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Network Traffic Compressed",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "pps",
-              "label": "packets out (-) / in (+)",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 50
           },
-          "hiddenSeries": false,
           "id": 146,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": 300,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "/.*Trans.*/",
-              "transform": "negative-Y"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_network_receive_multicast_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_network_receive_multicast_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{device}} - Receive multicast",
@@ -11689,95 +8145,35 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Network Traffic Multicast",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "pps",
-              "label": "packets out (-) / in (+)",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 50
           },
-          "hiddenSeries": false,
           "id": 144,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": 300,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "/.*Trans.*/",
-              "transform": "negative-Y"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_network_receive_fifo_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_network_receive_fifo_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{device}} - Receive fifo",
@@ -11785,7 +8181,11 @@
               "step": 240
             },
             {
-              "expr": "rate(node_network_transmit_fifo_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_network_transmit_fifo_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{device}} - Transmit fifo",
@@ -11793,96 +8193,35 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Network Traffic Fifo",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "pps",
-              "label": "packets out (-) / in (+)",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 60
           },
-          "hiddenSeries": false,
           "id": 145,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": 300,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:576",
-              "alias": "/.*Trans.*/",
-              "transform": "negative-Y"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_network_receive_frame_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_network_receive_frame_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -11891,92 +8230,35 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Network Traffic Frame",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:589",
-              "format": "pps",
-              "label": "packets out (-) / in (+)",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:590",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 60
           },
-          "hiddenSeries": false,
           "id": 231,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": 300,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_network_transmit_carrier_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_network_transmit_carrier_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{device}} - Statistic transmit_carrier",
@@ -11984,95 +8266,35 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Network Traffic Carrier",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "counter",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 70
           },
-          "hiddenSeries": false,
           "id": 232,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": 300,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "/.*Trans.*/",
-              "transform": "negative-Y"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_network_transmit_colls_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_network_transmit_colls_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{device}} - Transmit colls",
@@ -12080,92 +8302,35 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Network Traffic Colls",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "counter",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 70
           },
-          "hiddenSeries": false,
           "id": 61,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:663",
-              "alias": "NF conntrack limit",
-              "color": "#890F02",
-              "fill": 0
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_nf_conntrack_entries{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_nf_conntrack_entries{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "NF conntrack entries",
@@ -12173,7 +8338,11 @@
               "step": 240
             },
             {
-              "expr": "node_nf_conntrack_entries_limit{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_nf_conntrack_entries_limit{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "NF conntrack limit",
@@ -12181,88 +8350,35 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "NF Contrack",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:678",
-              "format": "short",
-              "label": "entries",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:679",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 80
           },
-          "hiddenSeries": false,
           "id": 230,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_arp_entries{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_arp_entries{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{ device }} - ARP entries",
@@ -12270,86 +8386,35 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "ARP Entries",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "Entries",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 80
           },
-          "hiddenSeries": false,
           "id": 288,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 1,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_network_mtu_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_network_mtu_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{ device }} - Bytes",
@@ -12357,87 +8422,35 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "MTU",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "decimals": 0,
-              "format": "bytes",
-              "label": "bytes",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 90
           },
-          "hiddenSeries": false,
           "id": 280,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 1,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_network_speed_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_network_speed_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{ device }} - Speed",
@@ -12445,87 +8458,35 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Speed",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "decimals": 0,
-              "format": "bytes",
-              "label": "bytes",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 90
           },
-          "hiddenSeries": false,
           "id": 289,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 1,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_network_transmit_queue_length{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_network_transmit_queue_length{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{ device }} -   Interface transmit queue length",
@@ -12533,98 +8494,35 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Queue Length",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "decimals": 0,
-              "format": "none",
-              "label": "packets",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 100
           },
-          "hiddenSeries": false,
           "id": 290,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": 300,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:232",
-              "alias": "/.*Dropped.*/",
-              "transform": "negative-Y"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_softnet_processed_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_softnet_processed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -12633,7 +8531,11 @@
               "step": 240
             },
             {
-              "expr": "rate(node_softnet_dropped_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_softnet_dropped_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -12642,92 +8544,35 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Softnet Packets",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:207",
-              "format": "short",
-              "label": "packetes drop (-) / process (+)",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:208",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 100
           },
-          "hiddenSeries": false,
           "id": 310,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": 300,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_softnet_times_squeezed_total{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_softnet_times_squeezed_total{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -12736,92 +8581,35 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Softnet Out of Quota",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:207",
-              "format": "short",
-              "label": "counter",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:208",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 110
           },
-          "hiddenSeries": false,
           "id": 309,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": 300,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_network_up{operstate=\"up\",supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_network_up{operstate=\"up\",supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{interface}} - Operational state UP",
@@ -12829,43 +8617,19 @@
               "step": 240
             },
             {
-              "expr": "node_network_carrier{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_network_carrier{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "instant": false,
               "legendFormat": "{{device}} - Physical link state",
               "refId": "B"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Network Operational Status",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "counter",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         }
       ],
       "title": "Network Traffic",
@@ -12873,10 +8637,6 @@
     },
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -12886,13 +8646,9 @@
       "id": 273,
       "panels": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "fieldConfig": {
             "defaults": {
@@ -12901,49 +8657,24 @@
             },
             "overrides": []
           },
-          "fill": 2,
-          "fillGradient": 0,
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 32
           },
-          "hiddenSeries": false,
           "id": 63,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": 300,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_sockstat_TCP_alloc{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_sockstat_TCP_alloc{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -12952,7 +8683,11 @@
               "step": 240
             },
             {
-              "expr": "node_sockstat_TCP_inuse{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_sockstat_TCP_inuse{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -12961,7 +8696,11 @@
               "step": 240
             },
             {
-              "expr": "node_sockstat_TCP_mem{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_sockstat_TCP_mem{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "hide": true,
               "interval": "",
@@ -12971,7 +8710,11 @@
               "step": 240
             },
             {
-              "expr": "node_sockstat_TCP_orphan{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_sockstat_TCP_orphan{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -12980,7 +8723,11 @@
               "step": 240
             },
             {
-              "expr": "node_sockstat_TCP_tw{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_sockstat_TCP_tw{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -12989,46 +8736,13 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Sockstat TCP",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "counter",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "fieldConfig": {
             "defaults": {
@@ -13037,49 +8751,24 @@
             },
             "overrides": []
           },
-          "fill": 2,
-          "fillGradient": 0,
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 32
           },
-          "hiddenSeries": false,
           "id": 124,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": 300,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_sockstat_UDPLITE_inuse{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_sockstat_UDPLITE_inuse{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -13088,7 +8777,11 @@
               "step": 240
             },
             {
-              "expr": "node_sockstat_UDP_inuse{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_sockstat_UDP_inuse{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -13097,7 +8790,11 @@
               "step": 240
             },
             {
-              "expr": "node_sockstat_UDP_mem{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_sockstat_UDP_mem{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -13106,46 +8803,13 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Sockstat UDP",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "counter",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "fieldConfig": {
             "defaults": {
@@ -13154,49 +8818,24 @@
             },
             "overrides": []
           },
-          "fill": 2,
-          "fillGradient": 0,
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 42
           },
-          "hiddenSeries": false,
           "id": 125,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": 300,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_sockstat_FRAG_inuse{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_sockstat_FRAG_inuse{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -13205,7 +8844,11 @@
               "step": 240
             },
             {
-              "expr": "node_sockstat_RAW_inuse{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_sockstat_RAW_inuse{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -13214,48 +8857,13 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Sockstat FRAG / RAW",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:1572",
-              "format": "short",
-              "label": "counter",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:1573",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "fieldConfig": {
             "defaults": {
@@ -13264,49 +8872,24 @@
             },
             "overrides": []
           },
-          "fill": 2,
-          "fillGradient": 0,
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 42
           },
-          "hiddenSeries": false,
           "id": 220,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": 300,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_sockstat_TCP_mem_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_sockstat_TCP_mem_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -13315,7 +8898,11 @@
               "step": 240
             },
             {
-              "expr": "node_sockstat_UDP_mem_bytes{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_sockstat_UDP_mem_bytes{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -13324,53 +8911,24 @@
               "step": 240
             },
             {
-              "expr": "node_sockstat_FRAG_memory{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_sockstat_FRAG_memory{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "interval": "",
               "intervalFactor": 1,
               "legendFormat": "FRAG_memory - Used memory for frag",
               "refId": "C"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Sockstat Memory Size",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "bytes",
-              "label": "bytes",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "fieldConfig": {
             "defaults": {
@@ -13379,49 +8937,24 @@
             },
             "overrides": []
           },
-          "fill": 2,
-          "fillGradient": 0,
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 52
           },
-          "hiddenSeries": false,
           "id": 126,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": 300,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_sockstat_sockets_used{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_sockstat_sockets_used{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -13430,37 +8963,8 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Sockstat Used",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "sockets",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         }
       ],
       "title": "Network Sockstat",
@@ -13468,10 +8972,6 @@
     },
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -13481,13 +8981,9 @@
       "id": 274,
       "panels": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "fieldConfig": {
             "defaults": {
@@ -13496,59 +8992,25 @@
             },
             "overrides": []
           },
-          "fill": 2,
-          "fillGradient": 0,
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 33
           },
-          "height": "",
-          "hiddenSeries": false,
           "id": 221,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": 300,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 12,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:1876",
-              "alias": "/.*Out.*/",
-              "transform": "negative-Y"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_netstat_IpExt_InOctets{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_netstat_IpExt_InOctets{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -13557,7 +9019,11 @@
               "step": 240
             },
             {
-              "expr": "rate(node_netstat_IpExt_OutOctets{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_netstat_IpExt_OutOctets{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "OutOctets - Sent octets",
@@ -13565,47 +9031,13 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Netstat IP In / Out Octets",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:1889",
-              "format": "short",
-              "label": "octects out (-) / in (+)",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:1890",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "fieldConfig": {
             "defaults": {
@@ -13614,52 +9046,24 @@
             },
             "overrides": []
           },
-          "fill": 2,
-          "fillGradient": 0,
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 33
           },
-          "height": "",
-          "hiddenSeries": false,
           "id": 81,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": 300,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_netstat_Ip_Forwarding{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_netstat_Ip_Forwarding{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -13668,48 +9072,13 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Netstat IP Forwarding",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:1957",
-              "format": "short",
-              "label": "datagrams",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:1958",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "fieldConfig": {
             "defaults": {
@@ -13718,56 +9087,25 @@
             },
             "overrides": []
           },
-          "fill": 2,
-          "fillGradient": 0,
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 43
           },
-          "height": "",
-          "hiddenSeries": false,
           "id": 115,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideZero": false,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 12,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "/.*Out.*/",
-              "transform": "negative-Y"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_netstat_Icmp_InMsgs{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_netstat_Icmp_InMsgs{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -13776,7 +9114,11 @@
               "step": 240
             },
             {
-              "expr": "rate(node_netstat_Icmp_OutMsgs{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_netstat_Icmp_OutMsgs{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -13785,45 +9127,13 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "ICMP In / Out",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "messages out (-) / in (+)",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "fieldConfig": {
             "defaults": {
@@ -13832,56 +9142,25 @@
             },
             "overrides": []
           },
-          "fill": 2,
-          "fillGradient": 0,
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 43
           },
-          "height": "",
-          "hiddenSeries": false,
           "id": 50,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideZero": false,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 12,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "/.*Out.*/",
-              "transform": "negative-Y"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_netstat_Icmp_InErrors{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_netstat_Icmp_InErrors{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -13890,45 +9169,13 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "ICMP Errors",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "messages out (-) / in (+)",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "fieldConfig": {
             "defaults": {
@@ -13937,60 +9184,25 @@
             },
             "overrides": []
           },
-          "fill": 2,
-          "fillGradient": 0,
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 53
           },
-          "height": "",
-          "hiddenSeries": false,
           "id": 55,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideZero": false,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 12,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "/.*Out.*/",
-              "transform": "negative-Y"
-            },
-            {
-              "alias": "/.*Snd.*/",
-              "transform": "negative-Y"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_netstat_Udp_InDatagrams{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_netstat_Udp_InDatagrams{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -13999,7 +9211,11 @@
               "step": 240
             },
             {
-              "expr": "rate(node_netstat_Udp_OutDatagrams{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_netstat_Udp_OutDatagrams{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -14008,45 +9224,13 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "UDP In / Out",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "datagrams out (-) / in (+)",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "fieldConfig": {
             "defaults": {
@@ -14055,51 +9239,25 @@
             },
             "overrides": []
           },
-          "fill": 2,
-          "fillGradient": 0,
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 53
           },
-          "height": "",
-          "hiddenSeries": false,
           "id": 109,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideZero": false,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 12,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_netstat_Udp_InErrors{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_netstat_Udp_InErrors{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -14108,7 +9266,11 @@
               "step": 240
             },
             {
-              "expr": "rate(node_netstat_Udp_NoPorts{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_netstat_Udp_NoPorts{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -14117,13 +9279,21 @@
               "step": 240
             },
             {
-              "expr": "rate(node_netstat_UdpLite_InErrors{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_netstat_UdpLite_InErrors{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "interval": "",
               "legendFormat": "InErrors Lite - UDPLite Datagrams that could not be delivered to an application",
               "refId": "C"
             },
             {
-              "expr": "rate(node_netstat_Udp_RcvbufErrors{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_netstat_Udp_RcvbufErrors{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -14132,7 +9302,11 @@
               "step": 240
             },
             {
-              "expr": "rate(node_netstat_Udp_SndbufErrors{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_netstat_Udp_SndbufErrors{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -14141,47 +9315,13 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "UDP Errors",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:4232",
-              "format": "short",
-              "label": "datagrams",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:4233",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "fieldConfig": {
             "defaults": {
@@ -14190,60 +9330,25 @@
             },
             "overrides": []
           },
-          "fill": 2,
-          "fillGradient": 0,
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 63
           },
-          "height": "",
-          "hiddenSeries": false,
           "id": 299,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideZero": false,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 12,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "/.*Out.*/",
-              "transform": "negative-Y"
-            },
-            {
-              "alias": "/.*Snd.*/",
-              "transform": "negative-Y"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_netstat_Tcp_InSegs{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_netstat_Tcp_InSegs{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -14253,7 +9358,11 @@
               "step": 240
             },
             {
-              "expr": "rate(node_netstat_Tcp_OutSegs{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_netstat_Tcp_OutSegs{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -14262,45 +9371,13 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "TCP In / Out",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "datagrams out (-) / in (+)",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "description": "",
           "fieldConfig": {
@@ -14310,52 +9387,25 @@
             },
             "overrides": []
           },
-          "fill": 2,
-          "fillGradient": 0,
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 63
           },
-          "height": "",
-          "hiddenSeries": false,
           "id": 104,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 12,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_netstat_TcpExt_ListenOverflows{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_netstat_TcpExt_ListenOverflows{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -14365,7 +9415,11 @@
               "step": 240
             },
             {
-              "expr": "rate(node_netstat_TcpExt_ListenDrops{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_netstat_TcpExt_ListenDrops{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -14375,7 +9429,11 @@
               "step": 240
             },
             {
-              "expr": "rate(node_netstat_TcpExt_TCPSynRetrans{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_netstat_TcpExt_TCPSynRetrans{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -14384,64 +9442,43 @@
               "step": 240
             },
             {
-              "expr": "rate(node_netstat_Tcp_RetransSegs{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_netstat_Tcp_RetransSegs{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "interval": "",
               "legendFormat": "RetransSegs - Segments retransmitted - that is, the number of TCP segments transmitted containing one or more previously transmitted octets",
               "refId": "D"
             },
             {
-              "expr": "rate(node_netstat_Tcp_InErrs{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_netstat_Tcp_InErrs{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "interval": "",
               "legendFormat": "InErrs - Segments received in error (e.g., bad TCP checksums)",
               "refId": "E"
             },
             {
-              "expr": "rate(node_netstat_Tcp_OutRsts{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_netstat_Tcp_OutRsts{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "interval": "",
               "legendFormat": "OutRsts - Segments sent with RST flag",
               "refId": "F"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "TCP Errors",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "counter",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "fieldConfig": {
             "defaults": {
@@ -14450,57 +9487,25 @@
             },
             "overrides": []
           },
-          "fill": 2,
-          "fillGradient": 0,
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 73
           },
-          "height": "",
-          "hiddenSeries": false,
           "id": 85,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideZero": false,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 12,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:454",
-              "alias": "/.*MaxConn *./",
-              "color": "#890F02",
-              "fill": 0
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_netstat_Tcp_CurrEstab{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_netstat_Tcp_CurrEstab{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -14510,7 +9515,11 @@
               "step": 240
             },
             {
-              "expr": "node_netstat_Tcp_MaxConn{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_netstat_Tcp_MaxConn{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -14520,48 +9529,13 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "TCP Connections",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:469",
-              "format": "short",
-              "label": "connections",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:470",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "description": "",
           "fieldConfig": {
@@ -14571,57 +9545,25 @@
             },
             "overrides": []
           },
-          "fill": 2,
-          "fillGradient": 0,
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 73
           },
-          "height": "",
-          "hiddenSeries": false,
           "id": 91,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 12,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "/.*Sent.*/",
-              "transform": "negative-Y"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_netstat_TcpExt_SyncookiesFailed{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_netstat_TcpExt_SyncookiesFailed{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -14631,7 +9573,11 @@
               "step": 240
             },
             {
-              "expr": "rate(node_netstat_TcpExt_SyncookiesRecv{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_netstat_TcpExt_SyncookiesRecv{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -14641,7 +9587,11 @@
               "step": 240
             },
             {
-              "expr": "rate(node_netstat_TcpExt_SyncookiesSent{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_netstat_TcpExt_SyncookiesSent{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -14651,45 +9601,13 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "TCP SynCookie",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "counter out (-) / in (+)",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "fieldConfig": {
             "defaults": {
@@ -14698,50 +9616,25 @@
             },
             "overrides": []
           },
-          "fill": 2,
-          "fillGradient": 0,
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 83
           },
-          "height": "",
-          "hiddenSeries": false,
           "id": 82,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideZero": false,
-            "max": true,
-            "min": true,
-            "rightSide": false,
-            "show": true,
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
           "maxPerRow": 12,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.7",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_netstat_Tcp_ActiveOpens{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_netstat_Tcp_ActiveOpens{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -14750,7 +9643,11 @@
               "step": 240
             },
             {
-              "expr": "rate(node_netstat_Tcp_PassiveOpens{supabase_project_ref=\"$project\"}[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "rate(node_netstat_Tcp_PassiveOpens{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -14759,37 +9656,8 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "TCP Direct Transition",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "connections",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         }
       ],
       "title": "Network Netstat",
@@ -14797,10 +9665,6 @@
     },
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -14810,55 +9674,32 @@
       "id": 279,
       "panels": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "description": "",
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
             "y": 54
           },
-          "hiddenSeries": false,
           "id": 40,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "show": true,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": true,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_scrape_collector_duration_seconds{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_scrape_collector_duration_seconds{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -14868,92 +9709,36 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Node Exporter Scrape Time",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "s",
-              "label": "seconds",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "grafanacloud-prom"
           },
           "description": "",
-          "fill": 2,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
             "y": 54
           },
-          "hiddenSeries": false,
           "id": 157,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:1969",
-              "alias": "/.*error.*/",
-              "color": "#F2495C",
-              "transform": "negative-Y"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": true,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "node_scrape_collector_success{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_scrape_collector_success{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -14963,7 +9748,11 @@
               "step": 240
             },
             {
-              "expr": "node_textfile_scrape_error{supabase_project_ref=\"$project\"}",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "expr": "node_textfile_scrape_error{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -14973,65 +9762,32 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Node Exporter Scrape",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:1484",
-              "format": "short",
-              "label": "counter",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:1485",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         }
       ],
       "title": "Node Exporter",
       "type": "row"
     }
   ],
+  "preload": false,
   "refresh": "",
-  "schemaVersion": 38,
-  "style": "dark",
+  "schemaVersion": 41,
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
-          "selected": false,
-          "text": "",
-          "value": ""
+          "text": "qfsrmwxxufryrczocwuj",
+          "value": "qfsrmwxxufryrczocwuj"
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "prometheus"
+          "uid": "grafanacloud-prom"
         },
         "definition": "label_values(supabase_project_ref)",
-        "hide": 0,
         "includeAll": false,
         "label": "Project Ref",
-        "multi": false,
         "name": "project",
         "options": [],
         "query": {
@@ -15040,22 +9796,15 @@
         },
         "refresh": 1,
         "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
         "type": "query"
       },
       {
-        "allValue": null,
         "current": {
-          "selected": false,
           "text": "[a-z]+|nvme[0-9]+n[0-9]+|mmcblk[0-9]+",
           "value": "[a-z]+|nvme[0-9]+n[0-9]+|mmcblk[0-9]+"
         },
-        "error": null,
         "hide": 2,
         "includeAll": false,
-        "label": null,
-        "multi": false,
         "name": "diskdevices",
         "options": [
           {
@@ -15065,8 +9814,30 @@
           }
         ],
         "query": "[a-z]+|nvme[0-9]+n[0-9]+|mmcblk[0-9]+",
-        "skipUrlSync": false,
         "type": "custom"
+      },
+      {
+        "allowCustomValue": false,
+        "current": {
+          "text": "qfsrmwxxufryrczocwuj",
+          "value": "qfsrmwxxufryrczocwuj"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "grafanacloud-prom"
+        },
+        "definition": "label_values(supabase_identifier)",
+        "includeAll": false,
+        "label": "Supabase Identifier",
+        "name": "supabase_identifier",
+        "options": [],
+        "query": {
+          "query": "label_values(supabase_identifier)",
+          "refId": "Prometheus-supabase_identifier-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
       }
     ]
   },
@@ -15077,7 +9848,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "Supabase Project",
-  "uid": "d402d94e-da48-48e4-ac52-53026b96a000",
-  "version": 3,
-  "weekStart": ""
+  "uid": "d402d94e-da48-48e4-ac52-53026b96a004",
+  "version": 4
 }

--- a/metrics.md
+++ b/metrics.md
@@ -1,1031 +1,1061 @@
-# HELP node_memory_SUnreclaim_bytes Memory information field SUnreclaim_bytes.
-# TYPE node_memory_SUnreclaim_bytes gauge
-node_memory_SUnreclaim_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_vmstat_oom_kill /proc/vmstat information field oom_kill.
-# TYPE node_vmstat_oom_kill untyped
-node_vmstat_oom_kill{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP pgbouncer_databases_pool_size Maximum number of server connections
-# TYPE pgbouncer_databases_pool_size gauge
-pgbouncer_databases_pool_size{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",force_user="pgbouncer",host="",name="pgbouncer",pool_mode="statement",port="6543"} 0
-# HELP node_network_transmit_errs_total Network device statistic transmit_errs.
-# TYPE node_network_transmit_errs_total counter
-node_network_transmit_errs_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
-# HELP node_memory_Active_anon_bytes Memory information field Active_anon_bytes.
-# TYPE node_memory_Active_anon_bytes gauge
-node_memory_Active_anon_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_memory_SwapTotal_bytes Memory information field SwapTotal_bytes.
-# TYPE node_memory_SwapTotal_bytes gauge
-node_memory_SwapTotal_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP pgbouncer_databases_disabled 1 if this database is currently disabled, else 0
-# TYPE pgbouncer_databases_disabled gauge
-pgbouncer_databases_disabled{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",force_user="pgbouncer",host="",name="pgbouncer",pool_mode="statement",port="6543"} 0
-# HELP pgbouncer_free_clients Count of free clients
-# TYPE pgbouncer_free_clients gauge
-pgbouncer_free_clients{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_filesystem_files Filesystem total file nodes.
-# TYPE node_filesystem_files gauge
-node_filesystem_files{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="/dev/nvme0n1p2",device_error="",fstype="ext4",mountpoint="/"} 0
-node_filesystem_files{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="/dev/nvme1n1",device_error="",fstype="ext4",mountpoint="/data"} 0
-# HELP node_memory_Inactive_anon_bytes Memory information field Inactive_anon_bytes.
-# TYPE node_memory_Inactive_anon_bytes gauge
-node_memory_Inactive_anon_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP pgbouncer_stats_queries_pooled_total Total number of SQL queries pooled
-# TYPE pgbouncer_stats_queries_pooled_total counter
-pgbouncer_stats_queries_pooled_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer"} 0
-# HELP node_network_transmit_drop_total Network device statistic transmit_drop.
-# TYPE node_network_transmit_drop_total counter
-node_network_transmit_drop_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
 # HELP node_disk_flush_requests_time_seconds_total This is the total number of seconds spent by all flush requests.
 # TYPE node_disk_flush_requests_time_seconds_total counter
-node_disk_flush_requests_time_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
-node_disk_flush_requests_time_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
-# HELP node_disk_discards_merged_total The total number of discards merged.
-# TYPE node_disk_discards_merged_total counter
-node_disk_discards_merged_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
-node_disk_discards_merged_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
-# HELP node_memory_MemTotal_bytes Memory information field MemTotal_bytes.
-# TYPE node_memory_MemTotal_bytes gauge
-node_memory_MemTotal_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_memory_ShmemPmdMapped_bytes Memory information field ShmemPmdMapped_bytes.
-# TYPE node_memory_ShmemPmdMapped_bytes gauge
-node_memory_ShmemPmdMapped_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP pgbouncer_databases_current_connections Current number of connections for this database
-# TYPE pgbouncer_databases_current_connections gauge
-pgbouncer_databases_current_connections{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",force_user="pgbouncer",host="",name="pgbouncer",pool_mode="statement",port="6543"} 0
-# HELP pgbouncer_pools_client_waiting_connections Client connections waiting on a server connection, shown as connection
-# TYPE pgbouncer_pools_client_waiting_connections gauge
-pgbouncer_pools_client_waiting_connections{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",user="pgbouncer"} 0
-# HELP node_memory_HardwareCorrupted_bytes Memory information field HardwareCorrupted_bytes.
-# TYPE node_memory_HardwareCorrupted_bytes gauge
-node_memory_HardwareCorrupted_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_vmstat_pgpgin /proc/vmstat information field pgpgin.
-# TYPE node_vmstat_pgpgin untyped
-node_vmstat_pgpgin{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_disk_read_time_seconds_total The total number of seconds spent by all reads.
-# TYPE node_disk_read_time_seconds_total counter
-node_disk_read_time_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
-node_disk_read_time_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
-# HELP node_filesystem_files_free Filesystem total free file nodes.
-# TYPE node_filesystem_files_free gauge
-node_filesystem_files_free{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="/dev/nvme0n1p2",device_error="",fstype="ext4",mountpoint="/"} 0
-node_filesystem_files_free{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="/dev/nvme1n1",device_error="",fstype="ext4",mountpoint="/data"} 0
-# HELP node_memory_Active_bytes Memory information field Active_bytes.
-# TYPE node_memory_Active_bytes gauge
-node_memory_Active_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_network_receive_drop_total Network device statistic receive_drop.
-# TYPE node_network_receive_drop_total counter
-node_network_receive_drop_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
-# HELP node_network_receive_nohandler_total Network device statistic receive_nohandler.
-# TYPE node_network_receive_nohandler_total counter
-node_network_receive_nohandler_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
-# HELP pgbouncer_stats_sql_transactions_pooled_total Total number of SQL transactions pooled
-# TYPE pgbouncer_stats_sql_transactions_pooled_total counter
-pgbouncer_stats_sql_transactions_pooled_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer"} 0
-# HELP node_memory_Committed_AS_bytes Memory information field Committed_AS_bytes.
-# TYPE node_memory_Committed_AS_bytes gauge
-node_memory_Committed_AS_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP pgbouncer_in_flight_dns_queries Count of in-flight DNS queries
-# TYPE pgbouncer_in_flight_dns_queries gauge
-pgbouncer_in_flight_dns_queries{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP pgbouncer_pools_server_testing_connections Server connections currently running either server_reset_query or server_check_query, shown as connection
-# TYPE pgbouncer_pools_server_testing_connections gauge
-pgbouncer_pools_server_testing_connections{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",user="pgbouncer"} 0
-# HELP pgbouncer_stats_server_in_transaction_seconds_total Total number of seconds spent by pgbouncer when connected to PostgreSQL in a transaction, either idle in transaction or executing queries
-# TYPE pgbouncer_stats_server_in_transaction_seconds_total counter
-pgbouncer_stats_server_in_transaction_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer"} 0
-# HELP pgbouncer_databases_max_connections Maximum number of allowed connections for this database
-# TYPE pgbouncer_databases_max_connections gauge
-pgbouncer_databases_max_connections{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",force_user="pgbouncer",host="",name="pgbouncer",pool_mode="statement",port="6543"} 0
-# HELP node_cpu_guest_seconds_total Seconds the CPUs spent in guests (VMs) for each mode.
-# TYPE node_cpu_guest_seconds_total counter
-node_cpu_guest_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="0",mode="nice"} 0
-node_cpu_guest_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="0",mode="user"} 0
-node_cpu_guest_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="1",mode="nice"} 0
-node_cpu_guest_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="1",mode="user"} 0
-# HELP node_disk_reads_merged_total The total number of reads merged.
-# TYPE node_disk_reads_merged_total counter
-node_disk_reads_merged_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
-node_disk_reads_merged_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
-# HELP node_memory_KernelStack_bytes Memory information field KernelStack_bytes.
-# TYPE node_memory_KernelStack_bytes gauge
-node_memory_KernelStack_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_memory_PageTables_bytes Memory information field PageTables_bytes.
-# TYPE node_memory_PageTables_bytes gauge
-node_memory_PageTables_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP pgbouncer_free_servers Count of free servers
-# TYPE pgbouncer_free_servers gauge
-pgbouncer_free_servers{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_load1 1m load average.
-# TYPE node_load1 gauge
-node_load1{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_memory_CommitLimit_bytes Memory information field CommitLimit_bytes.
-# TYPE node_memory_CommitLimit_bytes gauge
-node_memory_CommitLimit_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_memory_HugePages_Total Memory information field HugePages_Total.
-# TYPE node_memory_HugePages_Total gauge
-node_memory_HugePages_Total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_filesystem_free_bytes Filesystem free space in bytes.
-# TYPE node_filesystem_free_bytes gauge
-node_filesystem_free_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="/dev/nvme0n1p2",device_error="",fstype="ext4",mountpoint="/"} 0
-node_filesystem_free_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="/dev/nvme1n1",device_error="",fstype="ext4",mountpoint="/data"} 0
-# HELP node_network_receive_multicast_total Network device statistic receive_multicast.
-# TYPE node_network_receive_multicast_total counter
-node_network_receive_multicast_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
-# HELP node_scrape_collector_success node_exporter: Whether a collector succeeded.
-# TYPE node_scrape_collector_success gauge
-node_scrape_collector_success{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",collector="cpu"} 0
-node_scrape_collector_success{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",collector="diskstats"} 0
-node_scrape_collector_success{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",collector="filesystem"} 0
-node_scrape_collector_success{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",collector="loadavg"} 0
-node_scrape_collector_success{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",collector="meminfo"} 0
-node_scrape_collector_success{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",collector="netdev"} 0
-node_scrape_collector_success{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",collector="vmstat"} 0
-# HELP pgbouncer_pools_server_active_cancel_connections Server connections that are currently forwarding a cancel request.
-# TYPE pgbouncer_pools_server_active_cancel_connections gauge
-pgbouncer_pools_server_active_cancel_connections{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",user="pgbouncer"} 0
-# HELP node_filesystem_device_error Whether an error occurred while getting statistics for the given device.
-# TYPE node_filesystem_device_error gauge
-node_filesystem_device_error{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="/dev/nvme0n1p2",device_error="",fstype="ext4",mountpoint="/"} 0
-node_filesystem_device_error{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="/dev/nvme1n1",device_error="",fstype="ext4",mountpoint="/data"} 0
-# HELP node_network_receive_errs_total Network device statistic receive_errs.
-# TYPE node_network_receive_errs_total counter
-node_network_receive_errs_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
-# HELP pgbouncer_login_clients Count of clients in login state
-# TYPE pgbouncer_login_clients gauge
-pgbouncer_login_clients{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP pgbouncer_stats_client_wait_seconds_total Time spent by clients waiting for a server in seconds
-# TYPE pgbouncer_stats_client_wait_seconds_total counter
-pgbouncer_stats_client_wait_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer"} 0
-# HELP pgbouncer_up The pgbouncer scrape succeeded
-# TYPE pgbouncer_up gauge
-pgbouncer_up{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_disk_read_bytes_total The total number of bytes read successfully.
-# TYPE node_disk_read_bytes_total counter
-node_disk_read_bytes_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
-node_disk_read_bytes_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
-# HELP node_disk_written_bytes_total The total number of bytes written successfully.
-# TYPE node_disk_written_bytes_total counter
-node_disk_written_bytes_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
-node_disk_written_bytes_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
-# HELP node_network_receive_frame_total Network device statistic receive_frame.
-# TYPE node_network_receive_frame_total counter
-node_network_receive_frame_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
-# HELP pgbouncer_pools_server_used_connections Server connections idle more than server_check_delay, needing server_check_query, shown as connection
-# TYPE pgbouncer_pools_server_used_connections gauge
-pgbouncer_pools_server_used_connections{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",user="pgbouncer"} 0
-# HELP node_disk_io_time_seconds_total Total seconds spent doing I/Os.
-# TYPE node_disk_io_time_seconds_total counter
-node_disk_io_time_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
-node_disk_io_time_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
-# HELP node_memory_SReclaimable_bytes Memory information field SReclaimable_bytes.
-# TYPE node_memory_SReclaimable_bytes gauge
-node_memory_SReclaimable_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_memory_Slab_bytes Memory information field Slab_bytes.
-# TYPE node_memory_Slab_bytes gauge
-node_memory_Slab_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP pgbouncer_stats_sent_bytes_total Total volume in bytes of network traffic sent by pgbouncer, shown as bytes
-# TYPE pgbouncer_stats_sent_bytes_total counter
-pgbouncer_stats_sent_bytes_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer"} 0
-# HELP node_disk_io_time_weighted_seconds_total The weighted # of seconds spent doing I/Os.
-# TYPE node_disk_io_time_weighted_seconds_total counter
-node_disk_io_time_weighted_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
-node_disk_io_time_weighted_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
-# HELP node_memory_Cached_bytes Memory information field Cached_bytes.
-# TYPE node_memory_Cached_bytes gauge
-node_memory_Cached_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_memory_MemAvailable_bytes Memory information field MemAvailable_bytes.
-# TYPE node_memory_MemAvailable_bytes gauge
-node_memory_MemAvailable_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_memory_Mlocked_bytes Memory information field Mlocked_bytes.
-# TYPE node_memory_Mlocked_bytes gauge
-node_memory_Mlocked_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_memory_VmallocTotal_bytes Memory information field VmallocTotal_bytes.
-# TYPE node_memory_VmallocTotal_bytes gauge
-node_memory_VmallocTotal_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_network_receive_fifo_total Network device statistic receive_fifo.
-# TYPE node_network_receive_fifo_total counter
-node_network_receive_fifo_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
-# HELP node_network_transmit_packets_total Network device statistic transmit_packets.
-# TYPE node_network_transmit_packets_total counter
-node_network_transmit_packets_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
-# HELP pgbouncer_pools Count of pools
-# TYPE pgbouncer_pools gauge
-pgbouncer_pools{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_disk_info Info of /sys/block/<block_device>.
-# TYPE node_disk_info gauge
-node_disk_info{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1",major="259",minor="1",model="Amazon Elastic Block Store",path="pci-0000:00:04.0-nvme-1",revision="1.0",rotational="0",serial="vol000b117c48da3dfe3",wwn="nvme.1d0f-766f6c3030306231313763343864613364666533-416d617a6f6e20456c617374696320426c6f636b2053746f7265-00000001"} 0
-node_disk_info{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1",major="259",minor="0",model="Amazon Elastic Block Store",path="pci-0000:00:1f.0-nvme-1",revision="1.0",rotational="0",serial="vol0700061cdf99ba3cf",wwn="nvme.1d0f-766f6c3037303030363163646639396261336366-416d617a6f6e20456c617374696320426c6f636b2053746f7265-00000001"} 0
-# HELP node_disk_write_time_seconds_total This is the total number of seconds spent by all writes.
-# TYPE node_disk_write_time_seconds_total counter
-node_disk_write_time_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
-node_disk_write_time_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
-# HELP node_filesystem_avail_bytes Filesystem space available to non-root users in bytes.
-# TYPE node_filesystem_avail_bytes gauge
-node_filesystem_avail_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="/dev/nvme0n1p2",device_error="",fstype="ext4",mountpoint="/"} 0
-node_filesystem_avail_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="/dev/nvme1n1",device_error="",fstype="ext4",mountpoint="/data"} 0
-# HELP node_memory_Bounce_bytes Memory information field Bounce_bytes.
-# TYPE node_memory_Bounce_bytes gauge
-node_memory_Bounce_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_memory_Hugepagesize_bytes Memory information field Hugepagesize_bytes.
-# TYPE node_memory_Hugepagesize_bytes gauge
-node_memory_Hugepagesize_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_memory_Inactive_file_bytes Memory information field Inactive_file_bytes.
-# TYPE node_memory_Inactive_file_bytes gauge
-node_memory_Inactive_file_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_network_transmit_fifo_total Network device statistic transmit_fifo.
-# TYPE node_network_transmit_fifo_total counter
-node_network_transmit_fifo_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
-# HELP pgbouncer_pools_client_active_cancel_connections Client connections that have forwarded query cancellations to the server and are waiting for the server response
-# TYPE pgbouncer_pools_client_active_cancel_connections gauge
-pgbouncer_pools_client_active_cancel_connections{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",user="pgbouncer"} 0
+node_disk_flush_requests_time_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme0n1"} 0
+node_disk_flush_requests_time_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme1n1"} 0
 # HELP node_disk_reads_completed_total The total number of reads completed successfully.
 # TYPE node_disk_reads_completed_total counter
-node_disk_reads_completed_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
-node_disk_reads_completed_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
-# HELP node_memory_Inactive_bytes Memory information field Inactive_bytes.
-# TYPE node_memory_Inactive_bytes gauge
-node_memory_Inactive_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_memory_Shmem_bytes Memory information field Shmem_bytes.
-# TYPE node_memory_Shmem_bytes gauge
-node_memory_Shmem_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_load15 15m load average.
-# TYPE node_load15 gauge
-node_load15{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_network_receive_bytes_total Network device statistic receive_bytes.
-# TYPE node_network_receive_bytes_total counter
-node_network_receive_bytes_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
-# HELP pgbouncer_pools_client_maxwait_seconds Age of oldest unserved client connection, shown as second
-# TYPE pgbouncer_pools_client_maxwait_seconds gauge
-pgbouncer_pools_client_maxwait_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",user="pgbouncer"} 0
-# HELP pgbouncer_pools_server_being_canceled_connections Servers that normally could become idle but are waiting to do so until all in-flight cancel requests have completed that were sent to cancel a query on this server.
-# TYPE pgbouncer_pools_server_being_canceled_connections gauge
-pgbouncer_pools_server_being_canceled_connections{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",user="pgbouncer"} 0
-# HELP pgbouncer_version_info The pgbouncer version info
-# TYPE pgbouncer_version_info gauge
-pgbouncer_version_info{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",version="PgBouncer 1.19.0"} 0
-# HELP postgresql_restarts_total Number of times postgresql has been restarted
-# TYPE postgresql_restarts_total counter
-postgresql_restarts_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_memory_MemFree_bytes Memory information field MemFree_bytes.
-# TYPE node_memory_MemFree_bytes gauge
-node_memory_MemFree_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_network_transmit_colls_total Network device statistic transmit_colls.
-# TYPE node_network_transmit_colls_total counter
-node_network_transmit_colls_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
-# HELP node_memory_Active_file_bytes Memory information field Active_file_bytes.
-# TYPE node_memory_Active_file_bytes gauge
-node_memory_Active_file_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_memory_AnonHugePages_bytes Memory information field AnonHugePages_bytes.
-# TYPE node_memory_AnonHugePages_bytes gauge
-node_memory_AnonHugePages_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_memory_Buffers_bytes Memory information field Buffers_bytes.
-# TYPE node_memory_Buffers_bytes gauge
-node_memory_Buffers_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_disk_writes_merged_total The number of writes merged.
-# TYPE node_disk_writes_merged_total counter
-node_disk_writes_merged_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
-node_disk_writes_merged_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
-# HELP node_cpu_online CPUs that are online and being scheduled.
-# TYPE node_cpu_online gauge
-node_cpu_online{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="0"} 0
-node_cpu_online{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="1"} 0
-# HELP node_disk_flush_requests_total The total number of flush requests completed successfully
-# TYPE node_disk_flush_requests_total counter
-node_disk_flush_requests_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
-node_disk_flush_requests_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
-# HELP node_disk_writes_completed_total The total number of writes completed successfully.
-# TYPE node_disk_writes_completed_total counter
-node_disk_writes_completed_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
-node_disk_writes_completed_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
-# HELP node_memory_AnonPages_bytes Memory information field AnonPages_bytes.
-# TYPE node_memory_AnonPages_bytes gauge
-node_memory_AnonPages_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_network_transmit_carrier_total Network device statistic transmit_carrier.
-# TYPE node_network_transmit_carrier_total counter
-node_network_transmit_carrier_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
-# HELP node_disk_io_now The number of I/Os currently in progress.
-# TYPE node_disk_io_now gauge
-node_disk_io_now{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
-node_disk_io_now{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
-# HELP pgbouncer_pools_server_idle_connections Server connections idle and ready for a client query, shown as connection
-# TYPE pgbouncer_pools_server_idle_connections gauge
-pgbouncer_pools_server_idle_connections{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",user="pgbouncer"} 0
-# HELP pgbouncer_stats_received_bytes_total Total volume in bytes of network traffic received by pgbouncer, shown as bytes
-# TYPE pgbouncer_stats_received_bytes_total counter
-pgbouncer_stats_received_bytes_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer"} 0
-# HELP pgbouncer_used_servers Count of used servers
-# TYPE pgbouncer_used_servers gauge
-pgbouncer_used_servers{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_memory_Unevictable_bytes Memory information field Unevictable_bytes.
-# TYPE node_memory_Unevictable_bytes gauge
-node_memory_Unevictable_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_memory_VmallocChunk_bytes Memory information field VmallocChunk_bytes.
-# TYPE node_memory_VmallocChunk_bytes gauge
-node_memory_VmallocChunk_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP pgbouncer_pools_client_waiting_cancel_connections Client connections that have not forwarded query cancellations to the server yet
-# TYPE pgbouncer_pools_client_waiting_cancel_connections gauge
-pgbouncer_pools_client_waiting_cancel_connections{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",user="pgbouncer"} 0
-# HELP node_load5 5m load average.
-# TYPE node_load5 gauge
-node_load5{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_memory_WritebackTmp_bytes Memory information field WritebackTmp_bytes.
-# TYPE node_memory_WritebackTmp_bytes gauge
-node_memory_WritebackTmp_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_disk_filesystem_info Info about disk filesystem.
-# TYPE node_disk_filesystem_info gauge
-node_disk_filesystem_info{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1",type="ext4",usage="filesystem",uuid="b730046d-a571-41bc-b924-feb184b9171c",version="1.0"} 0
-# HELP node_memory_HugePages_Surp Memory information field HugePages_Surp.
-# TYPE node_memory_HugePages_Surp gauge
-node_memory_HugePages_Surp{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_network_transmit_bytes_total Network device statistic transmit_bytes.
-# TYPE node_network_transmit_bytes_total counter
-node_network_transmit_bytes_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
-# HELP node_network_transmit_compressed_total Network device statistic transmit_compressed.
-# TYPE node_network_transmit_compressed_total counter
-node_network_transmit_compressed_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
-# HELP node_disk_discarded_sectors_total The total number of sectors discarded successfully.
-# TYPE node_disk_discarded_sectors_total counter
-node_disk_discarded_sectors_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
-node_disk_discarded_sectors_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
-# HELP node_filesystem_mount_info Filesystem mount information.
-# TYPE node_filesystem_mount_info gauge
-node_filesystem_mount_info{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="/dev/nvme0n1p2",major="259",minor="3",mountpoint="/"} 0
-node_filesystem_mount_info{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="/dev/nvme1n1",major="259",minor="0",mountpoint="/data"} 0
-# HELP node_filesystem_size_bytes Filesystem size in bytes.
-# TYPE node_filesystem_size_bytes gauge
-node_filesystem_size_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="/dev/nvme0n1p2",device_error="",fstype="ext4",mountpoint="/"} 0
-node_filesystem_size_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="/dev/nvme1n1",device_error="",fstype="ext4",mountpoint="/data"} 0
-# HELP node_scrape_collector_duration_seconds node_exporter: Duration of a collector scrape.
-# TYPE node_scrape_collector_duration_seconds gauge
-node_scrape_collector_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",collector="cpu"} 0
-node_scrape_collector_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",collector="diskstats"} 0
-node_scrape_collector_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",collector="filesystem"} 0
-node_scrape_collector_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",collector="loadavg"} 0
-node_scrape_collector_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",collector="meminfo"} 0
-node_scrape_collector_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",collector="netdev"} 0
-node_scrape_collector_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",collector="vmstat"} 0
-# HELP pgbouncer_cached_dns_names Count of DNS names in the cache
-# TYPE pgbouncer_cached_dns_names gauge
-pgbouncer_cached_dns_names{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP pgbouncer_users Count of users
-# TYPE pgbouncer_users gauge
-pgbouncer_users{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_memory_Percpu_bytes Memory information field Percpu_bytes.
-# TYPE node_memory_Percpu_bytes gauge
-node_memory_Percpu_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_memory_SwapFree_bytes Memory information field SwapFree_bytes.
-# TYPE node_memory_SwapFree_bytes gauge
-node_memory_SwapFree_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP pgbouncer_config_max_user_connections Config maximum number of server connections per user
-# TYPE pgbouncer_config_max_user_connections gauge
-pgbouncer_config_max_user_connections{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP pgbouncer_pools_server_login_connections Server connections currently in the process of logging in, shown as connection
-# TYPE pgbouncer_pools_server_login_connections gauge
-pgbouncer_pools_server_login_connections{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",user="pgbouncer"} 0
-# HELP pgbouncer_stats_queries_duration_seconds_total Total number of seconds spent by pgbouncer when actively connected to PostgreSQL, executing queries
-# TYPE pgbouncer_stats_queries_duration_seconds_total counter
-pgbouncer_stats_queries_duration_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer"} 0
-# HELP node_memory_NFS_Unstable_bytes Memory information field NFS_Unstable_bytes.
-# TYPE node_memory_NFS_Unstable_bytes gauge
-node_memory_NFS_Unstable_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP pgbouncer_cached_dns_zones Count of DNS zones in the cache
-# TYPE pgbouncer_cached_dns_zones gauge
-pgbouncer_cached_dns_zones{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP pgbouncer_config_max_client_connections Config maximum number of client connections
-# TYPE pgbouncer_config_max_client_connections gauge
-pgbouncer_config_max_client_connections{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP pgbouncer_databases Count of databases
-# TYPE pgbouncer_databases gauge
-pgbouncer_databases{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP pgbouncer_pools_server_active_connections Server connections linked to a client connection, shown as connection
-# TYPE pgbouncer_pools_server_active_connections gauge
-pgbouncer_pools_server_active_connections{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",user="pgbouncer"} 0
-# HELP node_memory_HugePages_Rsvd Memory information field HugePages_Rsvd.
-# TYPE node_memory_HugePages_Rsvd gauge
-node_memory_HugePages_Rsvd{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP db_transmit_bytes postgres and pgbouncer network transmit bytes
-# TYPE db_transmit_bytes counter
-db_transmit_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_cpu_seconds_total Seconds the CPUs spent in each mode.
-# TYPE node_cpu_seconds_total counter
-node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="0",mode="idle"} 0
-node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="0",mode="iowait"} 0
-node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="0",mode="irq"} 0
-node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="0",mode="nice"} 0
-node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="0",mode="softirq"} 0
-node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="0",mode="steal"} 0
-node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="0",mode="system"} 0
-node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="0",mode="user"} 0
-node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="1",mode="idle"} 0
-node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="1",mode="iowait"} 0
-node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="1",mode="irq"} 0
-node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="1",mode="nice"} 0
-node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="1",mode="softirq"} 0
-node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="1",mode="steal"} 0
-node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="1",mode="system"} 0
-node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="1",mode="user"} 0
-# HELP node_memory_Writeback_bytes Memory information field Writeback_bytes.
-# TYPE node_memory_Writeback_bytes gauge
-node_memory_Writeback_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_vmstat_pgfault /proc/vmstat information field pgfault.
-# TYPE node_vmstat_pgfault untyped
-node_vmstat_pgfault{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_vmstat_pswpout /proc/vmstat information field pswpout.
-# TYPE node_vmstat_pswpout untyped
-node_vmstat_pswpout{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP pgbouncer_used_clients Count of used clients
-# TYPE pgbouncer_used_clients gauge
-pgbouncer_used_clients{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+node_disk_reads_completed_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme0n1"} 0
+node_disk_reads_completed_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme1n1"} 0
 # HELP node_memory_ShmemHugePages_bytes Memory information field ShmemHugePages_bytes.
 # TYPE node_memory_ShmemHugePages_bytes gauge
-node_memory_ShmemHugePages_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_network_receive_packets_total Network device statistic receive_packets.
-# TYPE node_network_receive_packets_total counter
-node_network_receive_packets_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
-# HELP node_vmstat_pgpgout /proc/vmstat information field pgpgout.
-# TYPE node_vmstat_pgpgout untyped
-node_vmstat_pgpgout{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_vmstat_pswpin /proc/vmstat information field pswpin.
-# TYPE node_vmstat_pswpin untyped
-node_vmstat_pswpin{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_disk_discards_completed_total The total number of discards completed successfully.
-# TYPE node_disk_discards_completed_total counter
-node_disk_discards_completed_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
-node_disk_discards_completed_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
-# HELP node_memory_Dirty_bytes Memory information field Dirty_bytes.
-# TYPE node_memory_Dirty_bytes gauge
-node_memory_Dirty_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_memory_Mapped_bytes Memory information field Mapped_bytes.
-# TYPE node_memory_Mapped_bytes gauge
-node_memory_Mapped_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_memory_VmallocUsed_bytes Memory information field VmallocUsed_bytes.
-# TYPE node_memory_VmallocUsed_bytes gauge
-node_memory_VmallocUsed_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_network_receive_compressed_total Network device statistic receive_compressed.
-# TYPE node_network_receive_compressed_total counter
-node_network_receive_compressed_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
-# HELP pgbouncer_databases_paused 1 if this database is currently paused, else 0
-# TYPE pgbouncer_databases_paused gauge
-pgbouncer_databases_paused{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",force_user="pgbouncer",host="",name="pgbouncer",pool_mode="statement",port="6543"} 0
+node_memory_ShmemHugePages_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_memory_VmallocChunk_bytes Memory information field VmallocChunk_bytes.
+# TYPE node_memory_VmallocChunk_bytes gauge
+node_memory_VmallocChunk_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_network_receive_bytes_total Network device statistic receive_bytes.
+# TYPE node_network_receive_bytes_total counter
+node_network_receive_bytes_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="ens5"} 0
+# HELP node_network_receive_multicast_total Network device statistic receive_multicast.
+# TYPE node_network_receive_multicast_total counter
+node_network_receive_multicast_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="ens5"} 0
+# HELP pgbouncer_cached_dns_names Count of DNS names in the cache
+# TYPE pgbouncer_cached_dns_names gauge
+pgbouncer_cached_dns_names{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP pgbouncer_in_flight_dns_queries Count of in-flight DNS queries
+# TYPE pgbouncer_in_flight_dns_queries gauge
+pgbouncer_in_flight_dns_queries{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_disk_writes_merged_total The number of writes merged.
+# TYPE node_disk_writes_merged_total counter
+node_disk_writes_merged_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme0n1"} 0
+node_disk_writes_merged_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme1n1"} 0
+# HELP node_filesystem_size_bytes Filesystem size in bytes.
+# TYPE node_filesystem_size_bytes gauge
+node_filesystem_size_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="/dev/nvme0n1p2",device_error="",fstype="ext4",mountpoint="/"} 0
+node_filesystem_size_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="/dev/nvme1n1",device_error="",fstype="ext4",mountpoint="/data"} 0
+# HELP node_memory_AnonPages_bytes Memory information field AnonPages_bytes.
+# TYPE node_memory_AnonPages_bytes gauge
+node_memory_AnonPages_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_memory_KernelStack_bytes Memory information field KernelStack_bytes.
+# TYPE node_memory_KernelStack_bytes gauge
+node_memory_KernelStack_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP pgbouncer_cached_dns_zones Count of DNS zones in the cache
+# TYPE pgbouncer_cached_dns_zones gauge
+pgbouncer_cached_dns_zones{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP pgbouncer_config_max_user_connections Config maximum number of server connections per user
+# TYPE pgbouncer_config_max_user_connections gauge
+pgbouncer_config_max_user_connections{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP pgbouncer_login_clients Count of clients in login state
+# TYPE pgbouncer_login_clients gauge
+pgbouncer_login_clients{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
 # HELP pgbouncer_pools_client_active_connections Client connections linked to server connection and able to process queries, shown as connection
 # TYPE pgbouncer_pools_client_active_connections gauge
-pgbouncer_pools_client_active_connections{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",user="pgbouncer"} 0
-# HELP node_disk_discard_time_seconds_total This is the total number of seconds spent by all discards.
-# TYPE node_disk_discard_time_seconds_total counter
-node_disk_discard_time_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
-node_disk_discard_time_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
-# HELP node_filesystem_readonly Filesystem read-only status.
-# TYPE node_filesystem_readonly gauge
-node_filesystem_readonly{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="/dev/nvme0n1p2",device_error="",fstype="ext4",mountpoint="/"} 0
-node_filesystem_readonly{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="/dev/nvme1n1",device_error="",fstype="ext4",mountpoint="/data"} 0
+pgbouncer_pools_client_active_connections{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",database="pgbouncer",user="pgbouncer"} 0
+# HELP node_load15 15m load average.
+# TYPE node_load15 gauge
+node_load15{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
 # HELP node_memory_HugePages_Free Memory information field HugePages_Free.
 # TYPE node_memory_HugePages_Free gauge
-node_memory_HugePages_Free{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
-# HELP node_memory_SwapCached_bytes Memory information field SwapCached_bytes.
-# TYPE node_memory_SwapCached_bytes gauge
-node_memory_SwapCached_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+node_memory_HugePages_Free{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_network_receive_compressed_total Network device statistic receive_compressed.
+# TYPE node_network_receive_compressed_total counter
+node_network_receive_compressed_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="ens5"} 0
+# HELP pgbouncer_databases Count of databases
+# TYPE pgbouncer_databases gauge
+pgbouncer_databases{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP pgbouncer_stats_sent_bytes_total Total volume in bytes of network traffic sent by pgbouncer, shown as bytes
+# TYPE pgbouncer_stats_sent_bytes_total counter
+pgbouncer_stats_sent_bytes_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",database="pgbouncer"} 0
+# HELP node_cpu_guest_seconds_total Seconds the CPUs spent in guests (VMs) for each mode.
+# TYPE node_cpu_guest_seconds_total counter
+node_cpu_guest_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",cpu="0",mode="nice"} 0
+node_cpu_guest_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",cpu="0",mode="user"} 0
+node_cpu_guest_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",cpu="1",mode="nice"} 0
+node_cpu_guest_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",cpu="1",mode="user"} 0
+# HELP node_memory_Active_bytes Memory information field Active_bytes.
+# TYPE node_memory_Active_bytes gauge
+node_memory_Active_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP pgbouncer_databases_paused 1 if this database is currently paused, else 0
+# TYPE pgbouncer_databases_paused gauge
+pgbouncer_databases_paused{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",database="pgbouncer",force_user="pgbouncer",host="",name="pgbouncer",pool_mode="statement",port="6543"} 0
+# HELP pgbouncer_stats_received_bytes_total Total volume in bytes of network traffic received by pgbouncer, shown as bytes
+# TYPE pgbouncer_stats_received_bytes_total counter
+pgbouncer_stats_received_bytes_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",database="pgbouncer"} 0
+# HELP pgbouncer_stats_sql_transactions_pooled_total Total number of SQL transactions pooled
+# TYPE pgbouncer_stats_sql_transactions_pooled_total counter
+pgbouncer_stats_sql_transactions_pooled_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",database="pgbouncer"} 0
+# HELP node_memory_Active_file_bytes Memory information field Active_file_bytes.
+# TYPE node_memory_Active_file_bytes gauge
+node_memory_Active_file_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_memory_Cached_bytes Memory information field Cached_bytes.
+# TYPE node_memory_Cached_bytes gauge
+node_memory_Cached_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP pgbouncer_databases_max_connections Maximum number of allowed connections for this database
+# TYPE pgbouncer_databases_max_connections gauge
+pgbouncer_databases_max_connections{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",database="pgbouncer",force_user="pgbouncer",host="",name="pgbouncer",pool_mode="statement",port="6543"} 0
+# HELP node_cpu_seconds_total Seconds the CPUs spent in each mode.
+# TYPE node_cpu_seconds_total counter
+node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",cpu="0",mode="idle"} 0
+node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",cpu="0",mode="iowait"} 0
+node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",cpu="0",mode="irq"} 0
+node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",cpu="0",mode="nice"} 0
+node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",cpu="0",mode="softirq"} 0
+node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",cpu="0",mode="steal"} 0
+node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",cpu="0",mode="system"} 0
+node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",cpu="0",mode="user"} 0
+node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",cpu="1",mode="idle"} 0
+node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",cpu="1",mode="iowait"} 0
+node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",cpu="1",mode="irq"} 0
+node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",cpu="1",mode="nice"} 0
+node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",cpu="1",mode="softirq"} 0
+node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",cpu="1",mode="steal"} 0
+node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",cpu="1",mode="system"} 0
+node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",cpu="1",mode="user"} 0
+# HELP node_memory_WritebackTmp_bytes Memory information field WritebackTmp_bytes.
+# TYPE node_memory_WritebackTmp_bytes gauge
+node_memory_WritebackTmp_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP pgbouncer_pools_server_active_connections Server connections linked to a client connection, shown as connection
+# TYPE pgbouncer_pools_server_active_connections gauge
+pgbouncer_pools_server_active_connections{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",database="pgbouncer",user="pgbouncer"} 0
+# HELP pgbouncer_pools_server_being_canceled_connections Servers that normally could become idle but are waiting to do so until all in-flight cancel requests have completed that were sent to cancel a query on this server.
+# TYPE pgbouncer_pools_server_being_canceled_connections gauge
+pgbouncer_pools_server_being_canceled_connections{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",database="pgbouncer",user="pgbouncer"} 0
+# HELP node_memory_HardwareCorrupted_bytes Memory information field HardwareCorrupted_bytes.
+# TYPE node_memory_HardwareCorrupted_bytes gauge
+node_memory_HardwareCorrupted_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_disk_written_bytes_total The total number of bytes written successfully.
+# TYPE node_disk_written_bytes_total counter
+node_disk_written_bytes_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme0n1"} 0
+node_disk_written_bytes_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme1n1"} 0
+# HELP node_memory_Inactive_bytes Memory information field Inactive_bytes.
+# TYPE node_memory_Inactive_bytes gauge
+node_memory_Inactive_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_scrape_collector_success node_exporter: Whether a collector succeeded.
+# TYPE node_scrape_collector_success gauge
+node_scrape_collector_success{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",collector="cpu"} 0
+node_scrape_collector_success{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",collector="diskstats"} 0
+node_scrape_collector_success{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",collector="filesystem"} 0
+node_scrape_collector_success{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",collector="loadavg"} 0
+node_scrape_collector_success{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",collector="meminfo"} 0
+node_scrape_collector_success{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",collector="netdev"} 0
+node_scrape_collector_success{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",collector="vmstat"} 0
+# HELP node_vmstat_oom_kill /proc/vmstat information field oom_kill.
+# TYPE node_vmstat_oom_kill untyped
+node_vmstat_oom_kill{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP pgbouncer_stats_queries_pooled_total Total number of SQL queries pooled
+# TYPE pgbouncer_stats_queries_pooled_total counter
+pgbouncer_stats_queries_pooled_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",database="pgbouncer"} 0
+# HELP node_disk_discard_time_seconds_total This is the total number of seconds spent by all discards.
+# TYPE node_disk_discard_time_seconds_total counter
+node_disk_discard_time_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme0n1"} 0
+node_disk_discard_time_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme1n1"} 0
+# HELP node_disk_discards_completed_total The total number of discards completed successfully.
+# TYPE node_disk_discards_completed_total counter
+node_disk_discards_completed_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme0n1"} 0
+node_disk_discards_completed_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme1n1"} 0
+# HELP node_load1 1m load average.
+# TYPE node_load1 gauge
+node_load1{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_memory_Mlocked_bytes Memory information field Mlocked_bytes.
+# TYPE node_memory_Mlocked_bytes gauge
+node_memory_Mlocked_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_network_receive_errs_total Network device statistic receive_errs.
+# TYPE node_network_receive_errs_total counter
+node_network_receive_errs_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="ens5"} 0
+# HELP node_network_receive_fifo_total Network device statistic receive_fifo.
+# TYPE node_network_receive_fifo_total counter
+node_network_receive_fifo_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="ens5"} 0
+# HELP node_network_receive_frame_total Network device statistic receive_frame.
+# TYPE node_network_receive_frame_total counter
+node_network_receive_frame_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="ens5"} 0
+# HELP node_vmstat_pgfault /proc/vmstat information field pgfault.
+# TYPE node_vmstat_pgfault untyped
+node_vmstat_pgfault{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_memory_Mapped_bytes Memory information field Mapped_bytes.
+# TYPE node_memory_Mapped_bytes gauge
+node_memory_Mapped_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_network_transmit_bytes_total Network device statistic transmit_bytes.
+# TYPE node_network_transmit_bytes_total counter
+node_network_transmit_bytes_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="ens5"} 0
+# HELP node_network_transmit_colls_total Network device statistic transmit_colls.
+# TYPE node_network_transmit_colls_total counter
+node_network_transmit_colls_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="ens5"} 0
+# HELP node_vmstat_pgpgin /proc/vmstat information field pgpgin.
+# TYPE node_vmstat_pgpgin untyped
+node_vmstat_pgpgin{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_filesystem_files Filesystem total file nodes.
+# TYPE node_filesystem_files gauge
+node_filesystem_files{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="/dev/nvme0n1p2",device_error="",fstype="ext4",mountpoint="/"} 0
+node_filesystem_files{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="/dev/nvme1n1",device_error="",fstype="ext4",mountpoint="/data"} 0
+# HELP node_memory_Inactive_anon_bytes Memory information field Inactive_anon_bytes.
+# TYPE node_memory_Inactive_anon_bytes gauge
+node_memory_Inactive_anon_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP pgbouncer_config_max_client_connections Config maximum number of client connections
+# TYPE pgbouncer_config_max_client_connections gauge
+pgbouncer_config_max_client_connections{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_cpu_online CPUs that are online and being scheduled.
+# TYPE node_cpu_online gauge
+node_cpu_online{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",cpu="0"} 0
+node_cpu_online{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",cpu="1"} 0
+# HELP node_disk_flush_requests_total The total number of flush requests completed successfully
+# TYPE node_disk_flush_requests_total counter
+node_disk_flush_requests_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme0n1"} 0
+node_disk_flush_requests_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme1n1"} 0
+# HELP pgbouncer_stats_server_in_transaction_seconds_total Total number of seconds spent by pgbouncer when connected to PostgreSQL in a transaction, either idle in transaction or executing queries
+# TYPE pgbouncer_stats_server_in_transaction_seconds_total counter
+pgbouncer_stats_server_in_transaction_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",database="pgbouncer"} 0
+# HELP node_disk_info Info of /sys/block/<block_device>.
+# TYPE node_disk_info gauge
+node_disk_info{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme0n1",major="259",minor="1",model="Amazon Elastic Block Store",path="pci-0000:00:04.0-nvme-1",revision="1.0",rotational="0",serial="vol000b117c48da3dfe3",wwn="nvme.1d0f-766f6c3030306231313763343864613364666533-416d617a6f6e20456c617374696320426c6f636b2053746f7265-00000001"} 0
+node_disk_info{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme1n1",major="259",minor="0",model="Amazon Elastic Block Store",path="pci-0000:00:1f.0-nvme-1",revision="1.0",rotational="0",serial="vol0700061cdf99ba3cf",wwn="nvme.1d0f-766f6c3037303030363163646639396261336366-416d617a6f6e20456c617374696320426c6f636b2053746f7265-00000001"} 0
+# HELP node_memory_MemFree_bytes Memory information field MemFree_bytes.
+# TYPE node_memory_MemFree_bytes gauge
+node_memory_MemFree_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_memory_SwapFree_bytes Memory information field SwapFree_bytes.
+# TYPE node_memory_SwapFree_bytes gauge
+node_memory_SwapFree_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_memory_HugePages_Rsvd Memory information field HugePages_Rsvd.
+# TYPE node_memory_HugePages_Rsvd gauge
+node_memory_HugePages_Rsvd{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_memory_PageTables_bytes Memory information field PageTables_bytes.
+# TYPE node_memory_PageTables_bytes gauge
+node_memory_PageTables_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_disk_writes_completed_total The total number of writes completed successfully.
+# TYPE node_disk_writes_completed_total counter
+node_disk_writes_completed_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme0n1"} 0
+node_disk_writes_completed_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme1n1"} 0
+# HELP pgbouncer_databases_current_connections Current number of connections for this database
+# TYPE pgbouncer_databases_current_connections gauge
+pgbouncer_databases_current_connections{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",database="pgbouncer",force_user="pgbouncer",host="",name="pgbouncer",pool_mode="statement",port="6543"} 0
+# HELP pgbouncer_free_servers Count of free servers
+# TYPE pgbouncer_free_servers gauge
+pgbouncer_free_servers{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP pgbouncer_pools_client_active_cancel_connections Client connections that have forwarded query cancellations to the server and are waiting for the server response
+# TYPE pgbouncer_pools_client_active_cancel_connections gauge
+pgbouncer_pools_client_active_cancel_connections{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",database="pgbouncer",user="pgbouncer"} 0
+# HELP node_memory_Bounce_bytes Memory information field Bounce_bytes.
+# TYPE node_memory_Bounce_bytes gauge
+node_memory_Bounce_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_memory_HugePages_Surp Memory information field HugePages_Surp.
+# TYPE node_memory_HugePages_Surp gauge
+node_memory_HugePages_Surp{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_memory_Percpu_bytes Memory information field Percpu_bytes.
+# TYPE node_memory_Percpu_bytes gauge
+node_memory_Percpu_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_memory_Unevictable_bytes Memory information field Unevictable_bytes.
+# TYPE node_memory_Unevictable_bytes gauge
+node_memory_Unevictable_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
 # HELP node_vmstat_pgmajfault /proc/vmstat information field pgmajfault.
 # TYPE node_vmstat_pgmajfault untyped
-node_vmstat_pgmajfault{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+node_vmstat_pgmajfault{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP pgbouncer_databases_pool_size Maximum number of server connections
+# TYPE pgbouncer_databases_pool_size gauge
+pgbouncer_databases_pool_size{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",database="pgbouncer",force_user="pgbouncer",host="",name="pgbouncer",pool_mode="statement",port="6543"} 0
+# HELP pgbouncer_pools_client_waiting_connections Client connections waiting on a server connection, shown as connection
+# TYPE pgbouncer_pools_client_waiting_connections gauge
+pgbouncer_pools_client_waiting_connections{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",database="pgbouncer",user="pgbouncer"} 0
+# HELP node_disk_filesystem_info Info about disk filesystem.
+# TYPE node_disk_filesystem_info gauge
+node_disk_filesystem_info{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme1n1",type="ext4",usage="filesystem",uuid="b730046d-a571-41bc-b924-feb184b9171c",version="1.0"} 0
+# HELP node_memory_ShmemPmdMapped_bytes Memory information field ShmemPmdMapped_bytes.
+# TYPE node_memory_ShmemPmdMapped_bytes gauge
+node_memory_ShmemPmdMapped_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_memory_Slab_bytes Memory information field Slab_bytes.
+# TYPE node_memory_Slab_bytes gauge
+node_memory_Slab_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_memory_VmallocTotal_bytes Memory information field VmallocTotal_bytes.
+# TYPE node_memory_VmallocTotal_bytes gauge
+node_memory_VmallocTotal_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_memory_VmallocUsed_bytes Memory information field VmallocUsed_bytes.
+# TYPE node_memory_VmallocUsed_bytes gauge
+node_memory_VmallocUsed_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP pgbouncer_free_clients Count of free clients
+# TYPE pgbouncer_free_clients gauge
+pgbouncer_free_clients{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP pgbouncer_pools_server_login_connections Server connections currently in the process of logging in, shown as connection
+# TYPE pgbouncer_pools_server_login_connections gauge
+pgbouncer_pools_server_login_connections{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",database="pgbouncer",user="pgbouncer"} 0
+# HELP pgbouncer_users Count of users
+# TYPE pgbouncer_users gauge
+pgbouncer_users{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_memory_Writeback_bytes Memory information field Writeback_bytes.
+# TYPE node_memory_Writeback_bytes gauge
+node_memory_Writeback_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP pgbouncer_stats_client_wait_seconds_total Time spent by clients waiting for a server in seconds
+# TYPE pgbouncer_stats_client_wait_seconds_total counter
+pgbouncer_stats_client_wait_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",database="pgbouncer"} 0
+# HELP node_filesystem_mount_info Filesystem mount information.
+# TYPE node_filesystem_mount_info gauge
+node_filesystem_mount_info{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="/dev/nvme0n1p2",major="259",minor="3",mountpoint="/"} 0
+node_filesystem_mount_info{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="/dev/nvme1n1",major="259",minor="0",mountpoint="/data"} 0
+# HELP node_memory_Active_anon_bytes Memory information field Active_anon_bytes.
+# TYPE node_memory_Active_anon_bytes gauge
+node_memory_Active_anon_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_memory_Dirty_bytes Memory information field Dirty_bytes.
+# TYPE node_memory_Dirty_bytes gauge
+node_memory_Dirty_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_memory_Hugepagesize_bytes Memory information field Hugepagesize_bytes.
+# TYPE node_memory_Hugepagesize_bytes gauge
+node_memory_Hugepagesize_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_memory_NFS_Unstable_bytes Memory information field NFS_Unstable_bytes.
+# TYPE node_memory_NFS_Unstable_bytes gauge
+node_memory_NFS_Unstable_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_memory_SwapTotal_bytes Memory information field SwapTotal_bytes.
+# TYPE node_memory_SwapTotal_bytes gauge
+node_memory_SwapTotal_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_network_transmit_fifo_total Network device statistic transmit_fifo.
+# TYPE node_network_transmit_fifo_total counter
+node_network_transmit_fifo_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="ens5"} 0
+# HELP pgbouncer_pools_server_active_cancel_connections Server connections that are currently forwarding a cancel request.
+# TYPE pgbouncer_pools_server_active_cancel_connections gauge
+pgbouncer_pools_server_active_cancel_connections{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",database="pgbouncer",user="pgbouncer"} 0
+# HELP pgbouncer_used_servers Count of used servers
+# TYPE pgbouncer_used_servers gauge
+pgbouncer_used_servers{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_memory_Inactive_file_bytes Memory information field Inactive_file_bytes.
+# TYPE node_memory_Inactive_file_bytes gauge
+node_memory_Inactive_file_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_network_transmit_carrier_total Network device statistic transmit_carrier.
+# TYPE node_network_transmit_carrier_total counter
+node_network_transmit_carrier_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="ens5"} 0
+# HELP node_network_transmit_compressed_total Network device statistic transmit_compressed.
+# TYPE node_network_transmit_compressed_total counter
+node_network_transmit_compressed_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="ens5"} 0
+# HELP pgbouncer_version_info The pgbouncer version info
+# TYPE pgbouncer_version_info gauge
+pgbouncer_version_info{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",version="PgBouncer 1.19.0"} 0
+# HELP node_disk_reads_merged_total The total number of reads merged.
+# TYPE node_disk_reads_merged_total counter
+node_disk_reads_merged_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme0n1"} 0
+node_disk_reads_merged_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme1n1"} 0
+# HELP node_filesystem_device_error Whether an error occurred while getting statistics for the given device.
+# TYPE node_filesystem_device_error gauge
+node_filesystem_device_error{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="/dev/nvme0n1p2",device_error="",fstype="ext4",mountpoint="/"} 0
+node_filesystem_device_error{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="/dev/nvme1n1",device_error="",fstype="ext4",mountpoint="/data"} 0
+# HELP node_filesystem_readonly Filesystem read-only status.
+# TYPE node_filesystem_readonly gauge
+node_filesystem_readonly{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="/dev/nvme0n1p2",device_error="",fstype="ext4",mountpoint="/"} 0
+node_filesystem_readonly{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="/dev/nvme1n1",device_error="",fstype="ext4",mountpoint="/data"} 0
+# HELP node_scrape_collector_duration_seconds node_exporter: Duration of a collector scrape.
+# TYPE node_scrape_collector_duration_seconds gauge
+node_scrape_collector_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",collector="cpu"} 0
+node_scrape_collector_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",collector="diskstats"} 0
+node_scrape_collector_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",collector="filesystem"} 0
+node_scrape_collector_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",collector="loadavg"} 0
+node_scrape_collector_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",collector="meminfo"} 0
+node_scrape_collector_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",collector="netdev"} 0
+node_scrape_collector_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",collector="vmstat"} 0
+# HELP pgbouncer_pools_server_testing_connections Server connections currently running either server_reset_query or server_check_query, shown as connection
+# TYPE pgbouncer_pools_server_testing_connections gauge
+pgbouncer_pools_server_testing_connections{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",database="pgbouncer",user="pgbouncer"} 0
+# HELP pgbouncer_pools_server_used_connections Server connections idle more than server_check_delay, needing server_check_query, shown as connection
+# TYPE pgbouncer_pools_server_used_connections gauge
+pgbouncer_pools_server_used_connections{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",database="pgbouncer",user="pgbouncer"} 0
+# HELP node_disk_write_time_seconds_total This is the total number of seconds spent by all writes.
+# TYPE node_disk_write_time_seconds_total counter
+node_disk_write_time_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme0n1"} 0
+node_disk_write_time_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme1n1"} 0
+# HELP node_memory_MemAvailable_bytes Memory information field MemAvailable_bytes.
+# TYPE node_memory_MemAvailable_bytes gauge
+node_memory_MemAvailable_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_memory_MemTotal_bytes Memory information field MemTotal_bytes.
+# TYPE node_memory_MemTotal_bytes gauge
+node_memory_MemTotal_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_network_transmit_errs_total Network device statistic transmit_errs.
+# TYPE node_network_transmit_errs_total counter
+node_network_transmit_errs_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="ens5"} 0
+# HELP node_network_transmit_packets_total Network device statistic transmit_packets.
+# TYPE node_network_transmit_packets_total counter
+node_network_transmit_packets_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="ens5"} 0
+# HELP pgbouncer_databases_disabled 1 if this database is currently disabled, else 0
+# TYPE pgbouncer_databases_disabled gauge
+pgbouncer_databases_disabled{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",database="pgbouncer",force_user="pgbouncer",host="",name="pgbouncer",pool_mode="statement",port="6543"} 0
+# HELP node_disk_io_time_weighted_seconds_total The weighted # of seconds spent doing I/Os.
+# TYPE node_disk_io_time_weighted_seconds_total counter
+node_disk_io_time_weighted_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme0n1"} 0
+node_disk_io_time_weighted_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme1n1"} 0
+# HELP node_disk_read_time_seconds_total The total number of seconds spent by all reads.
+# TYPE node_disk_read_time_seconds_total counter
+node_disk_read_time_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme0n1"} 0
+node_disk_read_time_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme1n1"} 0
+# HELP node_memory_CommitLimit_bytes Memory information field CommitLimit_bytes.
+# TYPE node_memory_CommitLimit_bytes gauge
+node_memory_CommitLimit_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_network_receive_drop_total Network device statistic receive_drop.
+# TYPE node_network_receive_drop_total counter
+node_network_receive_drop_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="ens5"} 0
+# HELP pgbouncer_pools_server_idle_connections Server connections idle and ready for a client query, shown as connection
+# TYPE pgbouncer_pools_server_idle_connections gauge
+pgbouncer_pools_server_idle_connections{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",database="pgbouncer",user="pgbouncer"} 0
+# HELP node_load5 5m load average.
+# TYPE node_load5 gauge
+node_load5{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP pgbouncer_stats_queries_duration_seconds_total Total number of seconds spent by pgbouncer when actively connected to PostgreSQL, executing queries
+# TYPE pgbouncer_stats_queries_duration_seconds_total counter
+pgbouncer_stats_queries_duration_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",database="pgbouncer"} 0
+# HELP pgbouncer_used_clients Count of used clients
+# TYPE pgbouncer_used_clients gauge
+pgbouncer_used_clients{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_disk_discarded_sectors_total The total number of sectors discarded successfully.
+# TYPE node_disk_discarded_sectors_total counter
+node_disk_discarded_sectors_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme0n1"} 0
+node_disk_discarded_sectors_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme1n1"} 0
+# HELP node_disk_io_time_seconds_total Total seconds spent doing I/Os.
+# TYPE node_disk_io_time_seconds_total counter
+node_disk_io_time_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme0n1"} 0
+node_disk_io_time_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme1n1"} 0
+# HELP node_memory_HugePages_Total Memory information field HugePages_Total.
+# TYPE node_memory_HugePages_Total gauge
+node_memory_HugePages_Total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_network_receive_packets_total Network device statistic receive_packets.
+# TYPE node_network_receive_packets_total counter
+node_network_receive_packets_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="ens5"} 0
+# HELP pgbouncer_pools_client_waiting_cancel_connections Client connections that have not forwarded query cancellations to the server yet
+# TYPE pgbouncer_pools_client_waiting_cancel_connections gauge
+pgbouncer_pools_client_waiting_cancel_connections{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",database="pgbouncer",user="pgbouncer"} 0
+# HELP pgbouncer_up The pgbouncer scrape succeeded
+# TYPE pgbouncer_up gauge
+pgbouncer_up{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_filesystem_avail_bytes Filesystem space available to non-root users in bytes.
+# TYPE node_filesystem_avail_bytes gauge
+node_filesystem_avail_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="/dev/nvme0n1p2",device_error="",fstype="ext4",mountpoint="/"} 0
+node_filesystem_avail_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="/dev/nvme1n1",device_error="",fstype="ext4",mountpoint="/data"} 0
+# HELP node_memory_Committed_AS_bytes Memory information field Committed_AS_bytes.
+# TYPE node_memory_Committed_AS_bytes gauge
+node_memory_Committed_AS_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_memory_Shmem_bytes Memory information field Shmem_bytes.
+# TYPE node_memory_Shmem_bytes gauge
+node_memory_Shmem_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_network_transmit_drop_total Network device statistic transmit_drop.
+# TYPE node_network_transmit_drop_total counter
+node_network_transmit_drop_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="ens5"} 0
+# HELP node_filesystem_files_free Filesystem total free file nodes.
+# TYPE node_filesystem_files_free gauge
+node_filesystem_files_free{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="/dev/nvme0n1p2",device_error="",fstype="ext4",mountpoint="/"} 0
+node_filesystem_files_free{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="/dev/nvme1n1",device_error="",fstype="ext4",mountpoint="/data"} 0
+# HELP node_memory_SUnreclaim_bytes Memory information field SUnreclaim_bytes.
+# TYPE node_memory_SUnreclaim_bytes gauge
+node_memory_SUnreclaim_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_memory_SwapCached_bytes Memory information field SwapCached_bytes.
+# TYPE node_memory_SwapCached_bytes gauge
+node_memory_SwapCached_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_disk_discards_merged_total The total number of discards merged.
+# TYPE node_disk_discards_merged_total counter
+node_disk_discards_merged_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme0n1"} 0
+node_disk_discards_merged_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme1n1"} 0
+# HELP node_memory_SReclaimable_bytes Memory information field SReclaimable_bytes.
+# TYPE node_memory_SReclaimable_bytes gauge
+node_memory_SReclaimable_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_vmstat_pswpin /proc/vmstat information field pswpin.
+# TYPE node_vmstat_pswpin untyped
+node_vmstat_pswpin{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_vmstat_pswpout /proc/vmstat information field pswpout.
+# TYPE node_vmstat_pswpout untyped
+node_vmstat_pswpout{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP postgresql_restarts_total Number of times postgresql has been restarted
+# TYPE postgresql_restarts_total counter
+postgresql_restarts_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_disk_read_bytes_total The total number of bytes read successfully.
+# TYPE node_disk_read_bytes_total counter
+node_disk_read_bytes_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme0n1"} 0
+node_disk_read_bytes_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme1n1"} 0
+# HELP node_filesystem_free_bytes Filesystem free space in bytes.
+# TYPE node_filesystem_free_bytes gauge
+node_filesystem_free_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="/dev/nvme0n1p2",device_error="",fstype="ext4",mountpoint="/"} 0
+node_filesystem_free_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="/dev/nvme1n1",device_error="",fstype="ext4",mountpoint="/data"} 0
+# HELP node_memory_Buffers_bytes Memory information field Buffers_bytes.
+# TYPE node_memory_Buffers_bytes gauge
+node_memory_Buffers_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
 # HELP pgbouncer_databases_reserve_pool Maximum number of additional connections for this database
 # TYPE pgbouncer_databases_reserve_pool gauge
-pgbouncer_databases_reserve_pool{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",force_user="pgbouncer",host="",name="pgbouncer",pool_mode="statement",port="6543"} 0
-# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
-# TYPE go_memstats_buck_hash_sys_bytes gauge
-go_memstats_buck_hash_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
-# TYPE go_memstats_mspan_sys_bytes gauge
-go_memstats_mspan_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
-# TYPE go_memstats_next_gc_bytes gauge
-go_memstats_next_gc_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP pg_exporter_user_queries_load_error Whether the user queries file was loaded and parsed successfully (1 for error, 0 for success).
-# TYPE pg_exporter_user_queries_load_error gauge
-pg_exporter_user_queries_load_error{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",filename="/opt/postgres_exporter/queries.yml",hashsum="67fac1f53396bb99d2c2c756b8c52a63cea18f41b5f079bb11a098d8e65007cc"} 0
-# HELP pg_settings_default_transaction_read_only Default transaction mode set to read only
-# TYPE pg_settings_default_transaction_read_only gauge
-pg_settings_default_transaction_read_only{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP pg_database_size_bytes Disk space used by the database
-# TYPE pg_database_size_bytes gauge
-pg_database_size_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",datname="postgres"} 0
-pg_database_size_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",datname="template0"} 0
-pg_database_size_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",datname="template1"} 0
-# HELP pg_exporter_last_scrape_duration_seconds Duration of the last scrape of metrics from PostgreSQL.
-# TYPE pg_exporter_last_scrape_duration_seconds gauge
-pg_exporter_last_scrape_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP pg_ls_archive_statusdir_wal_pending_count Number of not yet archived WAL files
-# TYPE pg_ls_archive_statusdir_wal_pending_count counter
-pg_ls_archive_statusdir_wal_pending_count{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP pg_stat_bgwriter_checkpoint_sync_time_total Time spent synchronizing checkpoint files to disk
-# TYPE pg_stat_bgwriter_checkpoint_sync_time_total counter
-pg_stat_bgwriter_checkpoint_sync_time_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP pg_stat_database_conflicts_confl_bufferpin_total Queries cancelled due to pinned buffers
-# TYPE pg_stat_database_conflicts_confl_bufferpin_total counter
-pg_stat_database_conflicts_confl_bufferpin_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP pg_stat_database_conflicts_confl_tablespace_total Queries cancelled due to dropped tablespaces
-# TYPE pg_stat_database_conflicts_confl_tablespace_total counter
-pg_stat_database_conflicts_confl_tablespace_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
-# TYPE go_memstats_heap_alloc_bytes gauge
-go_memstats_heap_alloc_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+pgbouncer_databases_reserve_pool{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",database="pgbouncer",force_user="pgbouncer",host="",name="pgbouncer",pool_mode="statement",port="6543"} 0
+# HELP pgbouncer_pools Count of pools
+# TYPE pgbouncer_pools gauge
+pgbouncer_pools{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP pgbouncer_pools_client_maxwait_seconds Age of oldest unserved client connection, shown as second
+# TYPE pgbouncer_pools_client_maxwait_seconds gauge
+pgbouncer_pools_client_maxwait_seconds{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",database="pgbouncer",user="pgbouncer"} 0
+# HELP node_memory_AnonHugePages_bytes Memory information field AnonHugePages_bytes.
+# TYPE node_memory_AnonHugePages_bytes gauge
+node_memory_AnonHugePages_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP db_transmit_bytes postgres and pgbouncer network transmit bytes
+# TYPE db_transmit_bytes counter
+db_transmit_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP node_disk_io_now The number of I/Os currently in progress.
+# TYPE node_disk_io_now gauge
+node_disk_io_now{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme0n1"} 0
+node_disk_io_now{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="nvme1n1"} 0
+# HELP node_network_receive_nohandler_total Network device statistic receive_nohandler.
+# TYPE node_network_receive_nohandler_total counter
+node_network_receive_nohandler_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db",device="ens5"} 0
+# HELP node_vmstat_pgpgout /proc/vmstat information field pgpgout.
+# TYPE node_vmstat_pgpgout untyped
+node_vmstat_pgpgout{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="db"} 0
+# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes gauge
+go_memstats_heap_released_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
 # HELP pg_database_size_mb Disk space used by the database
 # TYPE pg_database_size_mb gauge
-pg_database_size_mb{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP pg_stat_database_conflicts_confl_deadlock_total Queries cancelled due to deadlocks
-# TYPE pg_stat_database_conflicts_confl_deadlock_total counter
-pg_stat_database_conflicts_confl_deadlock_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP pg_stat_database_conflicts_confl_snapshot_total Queries cancelled due to old snapshots
-# TYPE pg_stat_database_conflicts_confl_snapshot_total counter
-pg_stat_database_conflicts_confl_snapshot_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP pg_stat_database_most_recent_reset The most recent time one of the databases had its statistics reset
-# TYPE pg_stat_database_most_recent_reset counter
-pg_stat_database_most_recent_reset{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP physical_replication_lag_is_wal_replay_paused Check if WAL replay has been paused
-# TYPE physical_replication_lag_is_wal_replay_paused gauge
-physical_replication_lag_is_wal_replay_paused{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP realtime_postgres_changes_total_subscriptions Total subscription records listening for Postgres changes
-# TYPE realtime_postgres_changes_total_subscriptions gauge
-realtime_postgres_changes_total_subscriptions{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP replication_slots_max_lag_bytes Max Replication Lag
-# TYPE replication_slots_max_lag_bytes gauge
-replication_slots_max_lag_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
-# TYPE go_memstats_gc_sys_bytes gauge
-go_memstats_gc_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP go_memstats_mallocs_total Total number of mallocs.
-# TYPE go_memstats_mallocs_total counter
-go_memstats_mallocs_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
-# TYPE go_memstats_mcache_sys_bytes gauge
-go_memstats_mcache_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
-# TYPE go_memstats_other_sys_bytes gauge
-go_memstats_other_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP go_memstats_sys_bytes Number of bytes obtained from system.
-# TYPE go_memstats_sys_bytes gauge
-go_memstats_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP pg_stat_bgwriter_buffers_backend_fsync_total fsync calls executed by a backend directly
-# TYPE pg_stat_bgwriter_buffers_backend_fsync_total counter
-pg_stat_bgwriter_buffers_backend_fsync_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP pg_stat_bgwriter_buffers_backend_total Buffers written directly by a backend
-# TYPE pg_stat_bgwriter_buffers_backend_total counter
-pg_stat_bgwriter_buffers_backend_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP pg_stat_bgwriter_stats_reset Most recent stat reset time
-# TYPE pg_stat_bgwriter_stats_reset counter
-pg_stat_bgwriter_stats_reset{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP pg_stat_database_blks_hit_total Disk blocks found in buffer cache
-# TYPE pg_stat_database_blks_hit_total counter
-pg_stat_database_blks_hit_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP pg_stat_database_conflicts_total Queries canceled due to conflicts with recovery
-# TYPE pg_stat_database_conflicts_total counter
-pg_stat_database_conflicts_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP pg_stat_database_temp_bytes_total Temp data written by queries
-# TYPE pg_stat_database_temp_bytes_total counter
-pg_stat_database_temp_bytes_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP pg_stat_database_tup_inserted_total Rows inserted
-# TYPE pg_stat_database_tup_inserted_total counter
-pg_stat_database_tup_inserted_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP pg_stat_statements_total_queries Number of times executed
-# TYPE pg_stat_statements_total_queries counter
-pg_stat_statements_total_queries{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP pg_stat_statements_total_time_seconds Total time spent, in seconds
-# TYPE pg_stat_statements_total_time_seconds counter
-pg_stat_statements_total_time_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP pg_wal_size_mb Disk space used by WAL files
-# TYPE pg_wal_size_mb gauge
-pg_wal_size_mb{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP postgres_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, goversion from which postgres_exporter was built, and the goos and goarch for the build.
-# TYPE postgres_exporter_build_info gauge
-postgres_exporter_build_info{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",branch="HEAD",goarch="arm64",goos="linux",goversion="go1.21.3",revision="68c176b8833b7580bf847cecf60f8e0ad5923f9a",tags="unknown",version="0.15.0"} 0
-# HELP connection_stats_connection_count Number of active connections
-# TYPE connection_stats_connection_count gauge
-connection_stats_connection_count{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432",username="authenticator"} 0
-connection_stats_connection_count{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432",username="other"} 0
-connection_stats_connection_count{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432",username="supabase_admin"} 0
-# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
-# TYPE go_memstats_stack_inuse_bytes gauge
-go_memstats_stack_inuse_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP pg_stat_bgwriter_buffers_clean_total Buffers written by bg writter
-# TYPE pg_stat_bgwriter_buffers_clean_total counter
-pg_stat_bgwriter_buffers_clean_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP pg_stat_bgwriter_checkpoints_timed_total Scheduled checkpoints performed
-# TYPE pg_stat_bgwriter_checkpoints_timed_total counter
-pg_stat_bgwriter_checkpoints_timed_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
-# TYPE process_cpu_seconds_total counter
-process_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP process_max_fds Maximum number of open file descriptors.
-# TYPE process_max_fds gauge
-process_max_fds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP process_resident_memory_bytes Resident memory size in bytes.
-# TYPE process_resident_memory_bytes gauge
-process_resident_memory_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP process_virtual_memory_bytes Virtual memory size in bytes.
-# TYPE process_virtual_memory_bytes gauge
-process_virtual_memory_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP go_memstats_heap_objects Number of allocated objects.
-# TYPE go_memstats_heap_objects gauge
-go_memstats_heap_objects{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP go_memstats_lookups_total Total number of pointer lookups.
-# TYPE go_memstats_lookups_total counter
-go_memstats_lookups_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP pg_stat_database_deadlocks_total Deadlocks detected
-# TYPE pg_stat_database_deadlocks_total counter
-pg_stat_database_deadlocks_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP pg_stat_database_temp_files_total Temp files created by queries
-# TYPE pg_stat_database_temp_files_total counter
-pg_stat_database_temp_files_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP physical_replication_lag_physical_replication_lag_seconds Physical replication lag in seconds
-# TYPE physical_replication_lag_physical_replication_lag_seconds gauge
-physical_replication_lag_physical_replication_lag_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
-# TYPE process_virtual_memory_max_bytes gauge
-process_virtual_memory_max_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
-# TYPE promhttp_metric_handler_requests_in_flight gauge
-promhttp_metric_handler_requests_in_flight{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
-# TYPE go_memstats_heap_idle_bytes gauge
-go_memstats_heap_idle_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
-# TYPE go_memstats_heap_sys_bytes gauge
-go_memstats_heap_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP go_threads Number of OS threads created.
-# TYPE go_threads gauge
-go_threads{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+pg_database_size_mb{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
 # HELP pg_stat_activity_xact_runtime Transaction Runtime
 # TYPE pg_stat_activity_xact_runtime gauge
-pg_stat_activity_xact_runtime{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP pg_stat_bgwriter_buffers_alloc_total Buffers allocated
-# TYPE pg_stat_bgwriter_buffers_alloc_total counter
-pg_stat_bgwriter_buffers_alloc_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP supabase_usage_metrics_revised_user_queries_total Unknown metric from supabase_usage_metrics_revised
-# TYPE supabase_usage_metrics_revised_user_queries_total untyped
-supabase_usage_metrics_revised_user_queries_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP auth_users_user_count Number of users in the project db
-# TYPE auth_users_user_count gauge
-auth_users_user_count{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP pg_exporter_last_scrape_error Whether the last scrape of metrics from PostgreSQL resulted in an error (1 for error, 0 for success).
-# TYPE pg_exporter_last_scrape_error gauge
-pg_exporter_last_scrape_error{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP pg_stat_bgwriter_maxwritten_clean_total Number of times bg writer stopped a cleaning scan because it had written too many buffers
-# TYPE pg_stat_bgwriter_maxwritten_clean_total counter
-pg_stat_bgwriter_maxwritten_clean_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP pg_stat_database_num_backends The number of active backends
-# TYPE pg_stat_database_num_backends gauge
-pg_stat_database_num_backends{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP pg_stat_replication_send_lag Max send lag
-# TYPE pg_stat_replication_send_lag gauge
-pg_stat_replication_send_lag{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP physical_replication_lag_is_connected_to_primary Monitor connection to the primary database
-# TYPE physical_replication_lag_is_connected_to_primary gauge
-physical_replication_lag_is_connected_to_primary{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP postgres_exporter_config_last_reload_successful Postgres exporter config loaded successfully.
-# TYPE postgres_exporter_config_last_reload_successful gauge
-postgres_exporter_config_last_reload_successful{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
-# TYPE promhttp_metric_handler_requests_total counter
-promhttp_metric_handler_requests_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",code="200"} 0
-promhttp_metric_handler_requests_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",code="500"} 0
-promhttp_metric_handler_requests_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",code="503"} 0
-# HELP go_memstats_frees_total Total number of frees.
-# TYPE go_memstats_frees_total counter
-go_memstats_frees_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
-# TYPE go_memstats_heap_released_bytes gauge
-go_memstats_heap_released_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
-# TYPE go_memstats_stack_sys_bytes gauge
-go_memstats_stack_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP go_info Information about the Go environment.
-# TYPE go_info gauge
-go_info{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",version="go1.21.3"} 0
-# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
-# TYPE go_memstats_mcache_inuse_bytes gauge
-go_memstats_mcache_inuse_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP max_connections_connection_count Maximum allowed connections
-# TYPE max_connections_connection_count gauge
-max_connections_connection_count{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP pg_scrape_collector_duration_seconds postgres_exporter: Duration of a collector scrape.
-# TYPE pg_scrape_collector_duration_seconds gauge
-pg_scrape_collector_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",collector="database"} 0
-# HELP pg_stat_database_xact_commit_total Transactions committed
-# TYPE pg_stat_database_xact_commit_total counter
-pg_stat_database_xact_commit_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+pg_stat_activity_xact_runtime{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_bgwriter_checkpoints_timed_total Scheduled checkpoints performed
+# TYPE pg_stat_bgwriter_checkpoints_timed_total counter
+pg_stat_bgwriter_checkpoints_timed_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
 # HELP pg_status_in_recovery Database in recovery
 # TYPE pg_status_in_recovery gauge
-pg_status_in_recovery{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP postgres_exporter_config_last_reload_success_timestamp_seconds Timestamp of the last successful configuration reload.
-# TYPE postgres_exporter_config_last_reload_success_timestamp_seconds gauge
-postgres_exporter_config_last_reload_success_timestamp_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP pg_scrape_collector_success postgres_exporter: Whether a collector succeeded.
-# TYPE pg_scrape_collector_success gauge
-pg_scrape_collector_success{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",collector="database"} 0
-# HELP pg_stat_bgwriter_checkpoint_write_time_total Time spent writing checkpoint files to disk
-# TYPE pg_stat_bgwriter_checkpoint_write_time_total counter
-pg_stat_bgwriter_checkpoint_write_time_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP pg_stat_database_conflicts_confl_lock_total Queries cancelled due to lock timeouts
-# TYPE pg_stat_database_conflicts_confl_lock_total counter
-pg_stat_database_conflicts_confl_lock_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP pg_up Whether the last scrape of metrics from PostgreSQL was able to connect to the server (1 for yes, 0 for no).
-# TYPE pg_up gauge
-pg_up{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP realtime_postgres_changes_client_subscriptions Client subscriptions listening for Postgres changes
-# TYPE realtime_postgres_changes_client_subscriptions gauge
-realtime_postgres_changes_client_subscriptions{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
-# TYPE go_memstats_heap_inuse_bytes gauge
-go_memstats_heap_inuse_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP pg_exporter_scrapes_total Total number of times PostgreSQL was scraped for metrics.
-# TYPE pg_exporter_scrapes_total counter
-pg_exporter_scrapes_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP pg_stat_database_blks_read_total Number of disk blocks read
-# TYPE pg_stat_database_blks_read_total counter
-pg_stat_database_blks_read_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP pg_stat_database_tup_deleted_total Rows deleted
-# TYPE pg_stat_database_tup_deleted_total counter
-pg_stat_database_tup_deleted_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP pg_stat_database_tup_fetched_total Rows fetched by queries
-# TYPE pg_stat_database_tup_fetched_total counter
-pg_stat_database_tup_fetched_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP process_open_fds Number of open file descriptors.
-# TYPE process_open_fds gauge
-process_open_fds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
-# TYPE process_start_time_seconds gauge
-process_start_time_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
-# TYPE go_memstats_last_gc_time_seconds gauge
-go_memstats_last_gc_time_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
-# TYPE go_gc_duration_seconds summary
-go_gc_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",quantile="0"} 0
-go_gc_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",quantile="0.25"} 0
-go_gc_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",quantile="0.5"} 0
-go_gc_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",quantile="0.75"} 0
-go_gc_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",quantile="1"} 0
-go_gc_duration_seconds_sum{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-go_gc_duration_seconds_count{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP go_goroutines Number of goroutines that currently exist.
-# TYPE go_goroutines gauge
-go_goroutines{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
-# TYPE go_memstats_mspan_inuse_bytes gauge
-go_memstats_mspan_inuse_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP pg_stat_bgwriter_buffers_checkpoint_total Buffers written during checkpoints
-# TYPE pg_stat_bgwriter_buffers_checkpoint_total counter
-pg_stat_bgwriter_buffers_checkpoint_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP pg_stat_bgwriter_checkpoints_req_total Requested checkpoints performed
-# TYPE pg_stat_bgwriter_checkpoints_req_total counter
-pg_stat_bgwriter_checkpoints_req_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP pg_stat_database_tup_returned_total Rows returned by queries
-# TYPE pg_stat_database_tup_returned_total counter
-pg_stat_database_tup_returned_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP pg_stat_database_tup_updated_total Rows updated
-# TYPE pg_stat_database_tup_updated_total counter
-pg_stat_database_tup_updated_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP pg_stat_replication_replay_lag Max replay lag
-# TYPE pg_stat_replication_replay_lag gauge
-pg_stat_replication_replay_lag{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
-# TYPE go_memstats_alloc_bytes gauge
-go_memstats_alloc_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
-# TYPE go_memstats_alloc_bytes_total counter
-go_memstats_alloc_bytes_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
-# HELP pg_stat_database_xact_rollback_total Transactions rolled back
-# TYPE pg_stat_database_xact_rollback_total counter
-pg_stat_database_xact_rollback_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP storage_storage_size_mb The total size used for all storage buckets, in mb
-# TYPE storage_storage_size_mb gauge
-storage_storage_size_mb{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP supabase_usage_metrics_user_queries_total The total number of user queries executed
-# TYPE supabase_usage_metrics_user_queries_total counter
-supabase_usage_metrics_user_queries_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
-# HELP pgrst_schema_cache_loads_total The total number of times the schema cache was loaded
-# TYPE pgrst_schema_cache_loads_total counter
-pgrst_schema_cache_loads_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgrest",status="FAIL"} 0
-pgrst_schema_cache_loads_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgrest",status="SUCCESS"} 0
-# HELP pgrst_db_pool_max Max pool connections
-# TYPE pgrst_db_pool_max gauge
-pgrst_db_pool_max{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgrest"} 0
-# HELP pgrst_db_pool_waiting Requests waiting to acquire a pool connection
-# TYPE pgrst_db_pool_waiting gauge
-pgrst_db_pool_waiting{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgrest"} 0
-# HELP pgrst_db_pool_available Available connections in the pool
-# TYPE pgrst_db_pool_available gauge
-pgrst_db_pool_available{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgrest"} 0
-# HELP pgrst_db_pool_timeouts_total The total number of pool connection timeouts
-# TYPE pgrst_db_pool_timeouts_total counter
-pgrst_db_pool_timeouts_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgrest"} 0
-# HELP pgrst_schema_cache_query_time_seconds The query time in seconds of the last schema cache load
-# TYPE pgrst_schema_cache_query_time_seconds gauge
-pgrst_schema_cache_query_time_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgrest"} 0
-# HELP go_memstats_heap_objects Number of allocated objects.
-# TYPE go_memstats_heap_objects gauge
-go_memstats_heap_objects{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
-# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
-# TYPE go_memstats_last_gc_time_seconds gauge
-go_memstats_last_gc_time_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
-# HELP go_memstats_mallocs_total Total number of mallocs.
-# TYPE go_memstats_mallocs_total counter
-go_memstats_mallocs_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
-# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
-# TYPE go_memstats_stack_inuse_bytes gauge
-go_memstats_stack_inuse_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
-# HELP go_threads Number of OS threads created.
-# TYPE go_threads gauge
-go_threads{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
-# HELP process_open_fds Number of open file descriptors.
-# TYPE process_open_fds gauge
-process_open_fds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
-# HELP go_goroutines Number of goroutines that currently exist.
-# TYPE go_goroutines gauge
-go_goroutines{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
-# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
-# TYPE go_memstats_mcache_sys_bytes gauge
-go_memstats_mcache_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
-# HELP process_runtime_go_mem_heap_alloc_bytes Bytes of allocated heap objects
-# TYPE process_runtime_go_mem_heap_alloc_bytes gauge
-process_runtime_go_mem_heap_alloc_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
-# HELP db_sql_connection_max_open Maximum number of open connections to the database
-# TYPE db_sql_connection_max_open gauge
-db_sql_connection_max_open{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="github.com/XSAM/otelsql",otel_scope_version="0.26.0"} 0
-# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
-# TYPE go_memstats_heap_inuse_bytes gauge
-go_memstats_heap_inuse_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
-# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
-# TYPE go_memstats_mspan_sys_bytes gauge
-go_memstats_mspan_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
-# HELP target_info Target metadata
-# TYPE target_info gauge
-target_info{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",service_name="unknown_service:auth",telemetry_sdk_language="go",telemetry_sdk_name="opentelemetry",telemetry_sdk_version="1.26.0"} 0
-# HELP db_sql_connection_open The number of established connections both in use and idle
-# TYPE db_sql_connection_open gauge
-db_sql_connection_open{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="github.com/XSAM/otelsql",otel_scope_version="0.26.0",status="idle"} 0
-db_sql_connection_open{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="github.com/XSAM/otelsql",otel_scope_version="0.26.0",status="inuse"} 0
-# HELP go_info Information about the Go environment.
-# TYPE go_info gauge
-go_info{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",version="go1.23.7"} 0
-# HELP process_runtime_go_mem_heap_idle_bytes Bytes in idle (unused) spans
-# TYPE process_runtime_go_mem_heap_idle_bytes gauge
-process_runtime_go_mem_heap_idle_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
-# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
-# TYPE go_memstats_heap_released_bytes gauge
-go_memstats_heap_released_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
-# HELP runtime_uptime_milliseconds_total Milliseconds since application was initialized
-# TYPE runtime_uptime_milliseconds_total counter
-runtime_uptime_milliseconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
-# HELP db_sql_connection_closed_max_idle_total The total number of connections closed due to SetMaxIdleConns
-# TYPE db_sql_connection_closed_max_idle_total counter
-db_sql_connection_closed_max_idle_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="github.com/XSAM/otelsql",otel_scope_version="0.26.0"} 0
-# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
-# TYPE go_memstats_heap_sys_bytes gauge
-go_memstats_heap_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
-# HELP process_runtime_go_mem_heap_inuse_bytes Bytes in in-use spans
-# TYPE process_runtime_go_mem_heap_inuse_bytes gauge
-process_runtime_go_mem_heap_inuse_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
-# HELP db_sql_connection_wait_total The total number of connections waited for
-# TYPE db_sql_connection_wait_total counter
-db_sql_connection_wait_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="github.com/XSAM/otelsql",otel_scope_version="0.26.0"} 0
-# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
-# TYPE go_gc_duration_seconds summary
-go_gc_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",quantile="0"} 0
-go_gc_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",quantile="0.25"} 0
-go_gc_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",quantile="0.5"} 0
-go_gc_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",quantile="0.75"} 0
-go_gc_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",quantile="1"} 0
-go_gc_duration_seconds_sum{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
-go_gc_duration_seconds_count{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
-# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
-# TYPE go_memstats_buck_hash_sys_bytes gauge
-go_memstats_buck_hash_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
-# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
-# TYPE go_memstats_heap_idle_bytes gauge
-go_memstats_heap_idle_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
-# HELP gotrue_running Whether GoTrue is running (always 1)
-# TYPE gotrue_running gauge
-gotrue_running{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="gotrue",otel_scope_version=""} 0
-# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
-# TYPE promhttp_metric_handler_requests_in_flight gauge
-promhttp_metric_handler_requests_in_flight{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
-# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
-# TYPE process_cpu_seconds_total counter
-process_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
-# HELP process_runtime_go_cgo_calls Number of cgo calls made by the current process
-# TYPE process_runtime_go_cgo_calls gauge
-process_runtime_go_cgo_calls{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
-# HELP process_runtime_go_mem_heap_released_bytes Bytes of idle spans whose physical memory has been returned to the OS
-# TYPE process_runtime_go_mem_heap_released_bytes gauge
-process_runtime_go_mem_heap_released_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
-# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
-# TYPE process_virtual_memory_max_bytes gauge
-process_virtual_memory_max_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+pg_status_in_recovery{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP physical_replication_lag_is_wal_replay_paused Check if WAL replay has been paused
+# TYPE physical_replication_lag_is_wal_replay_paused gauge
+physical_replication_lag_is_wal_replay_paused{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_database_conflicts_confl_bufferpin_total Queries cancelled due to pinned buffers
+# TYPE pg_stat_database_conflicts_confl_bufferpin_total counter
+pg_stat_database_conflicts_confl_bufferpin_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_statements_total_queries Number of times executed
+# TYPE pg_stat_statements_total_queries counter
+pg_stat_statements_total_queries{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_wal_size_mb Disk space used by WAL files
+# TYPE pg_wal_size_mb gauge
+pg_wal_size_mb{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP physical_replication_lag_physical_replication_lag_seconds Physical replication lag in seconds
+# TYPE physical_replication_lag_physical_replication_lag_seconds gauge
+physical_replication_lag_physical_replication_lag_seconds{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP postgres_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, goversion from which postgres_exporter was built, and the goos and goarch for the build.
+# TYPE postgres_exporter_build_info gauge
+postgres_exporter_build_info{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",branch="HEAD",goarch="arm64",goos="linux",goversion="go1.21.3",revision="68c176b8833b7580bf847cecf60f8e0ad5923f9a",tags="unknown",version="0.15.0"} 0
 # HELP process_resident_memory_bytes Resident memory size in bytes.
 # TYPE process_resident_memory_bytes gauge
-process_resident_memory_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
-# HELP process_runtime_go_gc_count_total Number of completed garbage collection cycles
-# TYPE process_runtime_go_gc_count_total counter
-process_runtime_go_gc_count_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
-# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
-# TYPE go_memstats_mspan_inuse_bytes gauge
-go_memstats_mspan_inuse_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
-# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
-# TYPE go_memstats_mcache_inuse_bytes gauge
-go_memstats_mcache_inuse_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
-# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
-# TYPE go_memstats_other_sys_bytes gauge
-go_memstats_other_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
-# HELP db_sql_connection_closed_max_idle_time_total The total number of connections closed due to SetConnMaxIdleTime
-# TYPE db_sql_connection_closed_max_idle_time_total counter
-db_sql_connection_closed_max_idle_time_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="github.com/XSAM/otelsql",otel_scope_version="0.26.0"} 0
-# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
-# TYPE go_memstats_gc_sys_bytes gauge
-go_memstats_gc_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
-# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
-# TYPE go_memstats_heap_alloc_bytes gauge
-go_memstats_heap_alloc_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="github.com/XSAM/otelsql",otel_scope_version="0.26.0"} 0
-otel_scope_info{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
-otel_scope_info{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="gotrue",otel_scope_version=""} 0
-# HELP process_runtime_go_gc_pause_ns Amount of nanoseconds in GC stop-the-world pauses
-# TYPE process_runtime_go_gc_pause_ns histogram
-process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="0"} 0
-process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="5"} 0
-process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="10"} 0
-process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="25"} 0
-process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="50"} 0
-process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="75"} 0
-process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="100"} 0
-process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="250"} 0
-process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="500"} 0
-process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="750"} 0
-process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="1000"} 0
-process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="2500"} 0
-process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="5000"} 0
-process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="7500"} 0
-process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="10000"} 0
-process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="+Inf"} 0
-process_runtime_go_gc_pause_ns_sum{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
-process_runtime_go_gc_pause_ns_count{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
-# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
-# TYPE promhttp_metric_handler_requests_total counter
-promhttp_metric_handler_requests_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",code="200"} 0
-promhttp_metric_handler_requests_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",code="500"} 0
-promhttp_metric_handler_requests_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",code="503"} 0
-# HELP process_runtime_go_gc_pause_total_ns_total Cumulative nanoseconds in GC stop-the-world pauses since the program started
-# TYPE process_runtime_go_gc_pause_total_ns_total counter
-process_runtime_go_gc_pause_total_ns_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
-# HELP db_sql_connection_wait_duration_milliseconds_total The total time blocked waiting for a new connection
-# TYPE db_sql_connection_wait_duration_milliseconds_total counter
-db_sql_connection_wait_duration_milliseconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="github.com/XSAM/otelsql",otel_scope_version="0.26.0"} 0
-# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
-# TYPE go_memstats_alloc_bytes_total counter
-go_memstats_alloc_bytes_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
-# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
-# TYPE go_memstats_next_gc_bytes gauge
-go_memstats_next_gc_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
-# HELP go_memstats_sys_bytes Number of bytes obtained from system.
-# TYPE go_memstats_sys_bytes gauge
-go_memstats_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
-# HELP process_max_fds Maximum number of open file descriptors.
-# TYPE process_max_fds gauge
-process_max_fds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
-# HELP process_runtime_go_mem_lookups_total Number of pointer lookups performed by the runtime
-# TYPE process_runtime_go_mem_lookups_total counter
-process_runtime_go_mem_lookups_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
-# HELP process_virtual_memory_bytes Virtual memory size in bytes.
-# TYPE process_virtual_memory_bytes gauge
-process_virtual_memory_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
-# HELP db_sql_connection_closed_max_lifetime_total The total number of connections closed due to SetConnMaxLifetime
-# TYPE db_sql_connection_closed_max_lifetime_total counter
-db_sql_connection_closed_max_lifetime_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="github.com/XSAM/otelsql",otel_scope_version="0.26.0"} 0
-# HELP go_memstats_frees_total Total number of frees.
-# TYPE go_memstats_frees_total counter
-go_memstats_frees_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
-# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
-# TYPE go_memstats_stack_sys_bytes gauge
-go_memstats_stack_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
-# HELP process_runtime_go_mem_heap_objects Number of allocated heap objects
-# TYPE process_runtime_go_mem_heap_objects gauge
-process_runtime_go_mem_heap_objects{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
-# HELP go_memstats_lookups_total Total number of pointer lookups.
-# TYPE go_memstats_lookups_total counter
-go_memstats_lookups_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
-# HELP process_runtime_go_mem_heap_sys_bytes Bytes of heap memory obtained from the OS
-# TYPE process_runtime_go_mem_heap_sys_bytes gauge
-process_runtime_go_mem_heap_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
-# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
-# TYPE process_start_time_seconds gauge
-process_start_time_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
-# HELP process_runtime_go_mem_live_objects Number of live objects is the number of cumulative Mallocs - Frees
-# TYPE process_runtime_go_mem_live_objects gauge
-process_runtime_go_mem_live_objects{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
-# HELP process_runtime_go_goroutines Number of goroutines that currently exist
-# TYPE process_runtime_go_goroutines gauge
-process_runtime_go_goroutines{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
+process_resident_memory_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
 # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
 # TYPE go_memstats_alloc_bytes gauge
-go_memstats_alloc_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+go_memstats_alloc_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE go_memstats_heap_inuse_bytes gauge
+go_memstats_heap_inuse_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP pg_scrape_collector_duration_seconds postgres_exporter: Duration of a collector scrape.
+# TYPE pg_scrape_collector_duration_seconds gauge
+pg_scrape_collector_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",collector="database"} 0
+# HELP pg_stat_bgwriter_maxwritten_clean_total Number of times bg writer stopped a cleaning scan because it had written too many buffers
+# TYPE pg_stat_bgwriter_maxwritten_clean_total counter
+pg_stat_bgwriter_maxwritten_clean_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_database_most_recent_reset The most recent time one of the databases had its statistics reset
+# TYPE pg_stat_database_most_recent_reset counter
+pg_stat_database_most_recent_reset{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} NaN
+# HELP pg_stat_database_tup_deleted_total Rows deleted
+# TYPE pg_stat_database_tup_deleted_total counter
+pg_stat_database_tup_deleted_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_statements_total_time_seconds Total time spent, in seconds
+# TYPE pg_stat_statements_total_time_seconds counter
+pg_stat_statements_total_time_seconds{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
+# TYPE promhttp_metric_handler_requests_total counter
+promhttp_metric_handler_requests_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",code="200"} 0
+promhttp_metric_handler_requests_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",code="500"} 0
+promhttp_metric_handler_requests_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",code="503"} 0
+# HELP pg_exporter_last_scrape_duration_seconds Duration of the last scrape of metrics from PostgreSQL.
+# TYPE pg_exporter_last_scrape_duration_seconds gauge
+pg_exporter_last_scrape_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP pg_ls_archive_statusdir_wal_pending_count Number of not yet archived WAL files
+# TYPE pg_ls_archive_statusdir_wal_pending_count counter
+pg_ls_archive_statusdir_wal_pending_count{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_bgwriter_buffers_alloc_total Buffers allocated
+# TYPE pg_stat_bgwriter_buffers_alloc_total counter
+pg_stat_bgwriter_buffers_alloc_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_database_temp_files_total Temp files created by queries
+# TYPE pg_stat_database_temp_files_total counter
+pg_stat_database_temp_files_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
+# TYPE promhttp_metric_handler_requests_in_flight gauge
+promhttp_metric_handler_requests_in_flight{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP replication_slots_max_lag_bytes Max Replication Lag
+# TYPE replication_slots_max_lag_bytes gauge
+replication_slots_max_lag_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} NaN
+# HELP supabase_usage_metrics_revised_user_queries_total Unknown metric from supabase_usage_metrics_revised
+# TYPE supabase_usage_metrics_revised_user_queries_total untyped
+supabase_usage_metrics_revised_user_queries_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+go_memstats_last_gc_time_seconds{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE go_memstats_mspan_sys_bytes gauge
+go_memstats_mspan_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE go_memstats_stack_sys_bytes gauge
+go_memstats_stack_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP pg_stat_database_deadlocks_total Deadlocks detected
+# TYPE pg_stat_database_deadlocks_total counter
+pg_stat_database_deadlocks_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_database_num_backends The number of active backends
+# TYPE pg_stat_database_num_backends gauge
+pg_stat_database_num_backends{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_database_xact_commit_total Transactions committed
+# TYPE pg_stat_database_xact_commit_total counter
+pg_stat_database_xact_commit_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_up Whether the last scrape of metrics from PostgreSQL was able to connect to the server (1 for yes, 0 for no).
+# TYPE pg_up gauge
+pg_up{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP connection_stats_connection_count Number of active connections
+# TYPE connection_stats_connection_count gauge
+connection_stats_connection_count{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432",username="authenticator"} 0
+connection_stats_connection_count{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432",username="other"} 0
+connection_stats_connection_count{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432",username="supabase_admin"} 0
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE go_memstats_heap_sys_bytes gauge
+go_memstats_heap_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE go_memstats_mcache_sys_bytes gauge
+go_memstats_mcache_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP pg_stat_database_tup_fetched_total Rows fetched by queries
+# TYPE pg_stat_database_tup_fetched_total counter
+pg_stat_database_tup_fetched_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP realtime_postgres_changes_total_subscriptions Total subscription records listening for Postgres changes
+# TYPE realtime_postgres_changes_total_subscriptions gauge
+realtime_postgres_changes_total_subscriptions{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_bgwriter_stats_reset Most recent stat reset time
+# TYPE pg_stat_bgwriter_stats_reset counter
+pg_stat_bgwriter_stats_reset{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+go_memstats_buck_hash_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP pg_stat_database_xact_rollback_total Transactions rolled back
+# TYPE pg_stat_database_xact_rollback_total counter
+pg_stat_database_xact_rollback_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP postgres_exporter_config_last_reload_successful Postgres exporter config loaded successfully.
+# TYPE postgres_exporter_config_last_reload_successful gauge
+postgres_exporter_config_last_reload_successful{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP auth_users_user_count Number of users in the project db
+# TYPE auth_users_user_count gauge
+auth_users_user_count{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE go_memstats_heap_alloc_bytes gauge
+go_memstats_heap_alloc_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+go_memstats_mcache_inuse_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP go_threads Number of OS threads created.
+# TYPE go_threads gauge
+go_threads{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP pg_exporter_last_scrape_error Whether the last scrape of metrics from PostgreSQL resulted in an error (1 for error, 0 for success).
+# TYPE pg_exporter_last_scrape_error gauge
+pg_exporter_last_scrape_error{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP pg_stat_bgwriter_buffers_clean_total Buffers written by bg writter
+# TYPE pg_stat_bgwriter_buffers_clean_total counter
+pg_stat_bgwriter_buffers_clean_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP pg_stat_bgwriter_buffers_checkpoint_total Buffers written during checkpoints
+# TYPE pg_stat_bgwriter_buffers_checkpoint_total counter
+pg_stat_bgwriter_buffers_checkpoint_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_database_blks_hit_total Disk blocks found in buffer cache
+# TYPE pg_stat_database_blks_hit_total counter
+pg_stat_database_blks_hit_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP postgres_exporter_config_last_reload_success_timestamp_seconds Timestamp of the last successful configuration reload.
+# TYPE postgres_exporter_config_last_reload_success_timestamp_seconds gauge
+postgres_exporter_config_last_reload_success_timestamp_seconds{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE go_memstats_alloc_bytes_total counter
+go_memstats_alloc_bytes_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP go_memstats_frees_total Total number of frees.
+# TYPE go_memstats_frees_total counter
+go_memstats_frees_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP go_memstats_lookups_total Total number of pointer lookups.
+# TYPE go_memstats_lookups_total counter
+go_memstats_lookups_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP pg_stat_bgwriter_buffers_backend_total Buffers written directly by a backend
+# TYPE pg_stat_bgwriter_buffers_backend_total counter
+pg_stat_bgwriter_buffers_backend_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_database_tup_returned_total Rows returned by queries
+# TYPE pg_stat_database_tup_returned_total counter
+pg_stat_database_tup_returned_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE go_memstats_heap_idle_bytes gauge
+go_memstats_heap_idle_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP max_connections_connection_count Maximum allowed connections
+# TYPE max_connections_connection_count gauge
+max_connections_connection_count{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_settings_default_transaction_read_only Default transaction mode set to read only
+# TYPE pg_settings_default_transaction_read_only gauge
+pg_settings_default_transaction_read_only{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP realtime_postgres_changes_client_subscriptions Client subscriptions listening for Postgres changes
+# TYPE realtime_postgres_changes_client_subscriptions gauge
+realtime_postgres_changes_client_subscriptions{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP go_memstats_sys_bytes Number of bytes obtained from system.
+# TYPE go_memstats_sys_bytes gauge
+go_memstats_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP pg_exporter_user_queries_load_error Whether the user queries file was loaded and parsed successfully (1 for error, 0 for success).
+# TYPE pg_exporter_user_queries_load_error gauge
+pg_exporter_user_queries_load_error{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",filename="/opt/postgres_exporter/queries.yml",hashsum="67fac1f53396bb99d2c2c756b8c52a63cea18f41b5f079bb11a098d8e65007cc"} 0
+# HELP pg_stat_database_conflicts_confl_snapshot_total Queries cancelled due to old snapshots
+# TYPE pg_stat_database_conflicts_confl_snapshot_total counter
+pg_stat_database_conflicts_confl_snapshot_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_replication_replay_lag Max replay lag
+# TYPE pg_stat_replication_replay_lag gauge
+pg_stat_replication_replay_lag{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP storage_storage_size_mb The total size used for all storage buckets, in mb
+# TYPE storage_storage_size_mb gauge
+storage_storage_size_mb{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE go_memstats_other_sys_bytes gauge
+go_memstats_other_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP pg_stat_database_blks_read_total Number of disk blocks read
+# TYPE pg_stat_database_blks_read_total counter
+pg_stat_database_blks_read_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP physical_replication_lag_is_connected_to_primary Monitor connection to the primary database
+# TYPE physical_replication_lag_is_connected_to_primary gauge
+physical_replication_lag_is_connected_to_primary{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP supabase_usage_metrics_user_queries_total The total number of user queries executed
+# TYPE supabase_usage_metrics_user_queries_total counter
+supabase_usage_metrics_user_queries_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP go_memstats_mallocs_total Total number of mallocs.
+# TYPE go_memstats_mallocs_total counter
+go_memstats_mallocs_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP pg_database_size_bytes Disk space used by the database
+# TYPE pg_database_size_bytes gauge
+pg_database_size_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",datname="postgres"} 0
+pg_database_size_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",datname="template0"} 0
+pg_database_size_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",datname="template1"} 0
+# HELP pg_stat_database_conflicts_confl_deadlock_total Queries cancelled due to deadlocks
+# TYPE pg_stat_database_conflicts_confl_deadlock_total counter
+pg_stat_database_conflicts_confl_deadlock_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_database_conflicts_total Queries canceled due to conflicts with recovery
+# TYPE pg_stat_database_conflicts_total counter
+pg_stat_database_conflicts_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_database_tup_inserted_total Rows inserted
+# TYPE pg_stat_database_tup_inserted_total counter
+pg_stat_database_tup_inserted_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
+# TYPE process_virtual_memory_max_bytes gauge
+process_virtual_memory_max_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",quantile="0"} 0
+go_gc_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",quantile="0.25"} 0
+go_gc_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",quantile="0.5"} 0
+go_gc_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",quantile="0.75"} 0
+go_gc_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",quantile="1"} 0
+go_gc_duration_seconds_sum{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+go_gc_duration_seconds_count{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP go_memstats_heap_objects Number of allocated objects.
+# TYPE go_memstats_heap_objects gauge
+go_memstats_heap_objects{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+go_memstats_mspan_inuse_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE go_memstats_stack_inuse_bytes gauge
+go_memstats_stack_inuse_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP pg_exporter_scrapes_total Total number of times PostgreSQL was scraped for metrics.
+# TYPE pg_exporter_scrapes_total counter
+pg_exporter_scrapes_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP pg_scrape_collector_success postgres_exporter: Whether a collector succeeded.
+# TYPE pg_scrape_collector_success gauge
+pg_scrape_collector_success{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",collector="database"} 0
+# HELP pg_stat_bgwriter_checkpoint_sync_time_total Time spent synchronizing checkpoint files to disk
+# TYPE pg_stat_bgwriter_checkpoint_sync_time_total counter
+pg_stat_bgwriter_checkpoint_sync_time_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_database_conflicts_confl_tablespace_total Queries cancelled due to dropped tablespaces
+# TYPE pg_stat_database_conflicts_confl_tablespace_total counter
+pg_stat_database_conflicts_confl_tablespace_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_bgwriter_checkpoint_write_time_total Time spent writing checkpoint files to disk
+# TYPE pg_stat_bgwriter_checkpoint_write_time_total counter
+pg_stat_bgwriter_checkpoint_write_time_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_bgwriter_checkpoints_req_total Requested checkpoints performed
+# TYPE pg_stat_bgwriter_checkpoints_req_total counter
+pg_stat_bgwriter_checkpoints_req_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE go_memstats_next_gc_bytes gauge
+go_memstats_next_gc_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP pg_stat_bgwriter_buffers_backend_fsync_total fsync calls executed by a backend directly
+# TYPE pg_stat_bgwriter_buffers_backend_fsync_total counter
+pg_stat_bgwriter_buffers_backend_fsync_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_database_conflicts_confl_lock_total Queries cancelled due to lock timeouts
+# TYPE pg_stat_database_conflicts_confl_lock_total counter
+pg_stat_database_conflicts_confl_lock_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_database_temp_bytes_total Temp data written by queries
+# TYPE pg_stat_database_temp_bytes_total counter
+pg_stat_database_temp_bytes_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_database_tup_updated_total Rows updated
+# TYPE pg_stat_database_tup_updated_total counter
+pg_stat_database_tup_updated_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_replication_send_lag Max send lag
+# TYPE pg_stat_replication_send_lag gauge
+pg_stat_replication_send_lag{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",server="localhost:5432"} 0
+# HELP go_info Information about the Go environment.
+# TYPE go_info gauge
+go_info{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql",version="go1.21.3"} 0
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE go_memstats_gc_sys_bytes gauge
+go_memstats_gc_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgresql"} 0
+# HELP pgrst_schema_cache_loads_total The total number of times the schema cache was loaded
+# TYPE pgrst_schema_cache_loads_total counter
+pgrst_schema_cache_loads_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgrest",status="FAIL"} 0
+pgrst_schema_cache_loads_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgrest",status="SUCCESS"} 0
+# HELP pgrst_db_pool_max Max pool connections
+# TYPE pgrst_db_pool_max gauge
+pgrst_db_pool_max{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgrest"} 0
+# HELP pgrst_db_pool_waiting Requests waiting to acquire a pool connection
+# TYPE pgrst_db_pool_waiting gauge
+pgrst_db_pool_waiting{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgrest"} 0
+# HELP pgrst_db_pool_available Available connections in the pool
+# TYPE pgrst_db_pool_available gauge
+pgrst_db_pool_available{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgrest"} 0
+# HELP pgrst_db_pool_timeouts_total The total number of pool connection timeouts
+# TYPE pgrst_db_pool_timeouts_total counter
+pgrst_db_pool_timeouts_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgrest"} 0
+# HELP pgrst_schema_cache_query_time_seconds The query time in seconds of the last schema cache load
+# TYPE pgrst_schema_cache_query_time_seconds gauge
+pgrst_schema_cache_query_time_seconds{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="postgrest"} 0
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE go_memstats_other_sys_bytes gauge
+go_memstats_other_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP http_server_response_size_bytes_total Measures the size of HTTP response messages.
+# TYPE http_server_response_size_bytes_total counter
+http_server_response_size_bytes_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",http_method="GET",http_scheme="http",http_status_code="200",net_host_name="abcdefghijkl.supabase.co",net_protocol_name="http",net_protocol_version="1.1",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",otel_scope_version="0.51.0"} 0
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
+# TYPE promhttp_metric_handler_requests_total counter
+promhttp_metric_handler_requests_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",code="200"} 0
+promhttp_metric_handler_requests_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",code="500"} 0
+promhttp_metric_handler_requests_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",code="503"} 0
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE go_memstats_heap_sys_bytes gauge
+go_memstats_heap_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP process_runtime_go_mem_lookups_total Number of pointer lookups performed by the runtime
+# TYPE process_runtime_go_mem_lookups_total counter
+process_runtime_go_mem_lookups_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
+# HELP process_runtime_go_mem_heap_sys_bytes Bytes of heap memory obtained from the OS
+# TYPE process_runtime_go_mem_heap_sys_bytes gauge
+process_runtime_go_mem_heap_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP db_sql_connection_closed_max_idle_time_total The total number of connections closed due to SetConnMaxIdleTime
+# TYPE db_sql_connection_closed_max_idle_time_total counter
+db_sql_connection_closed_max_idle_time_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="github.com/XSAM/otelsql",otel_scope_version="0.26.0"} 0
+# HELP db_sql_connection_wait_duration_milliseconds_total The total time blocked waiting for a new connection
+# TYPE db_sql_connection_wait_duration_milliseconds_total counter
+db_sql_connection_wait_duration_milliseconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="github.com/XSAM/otelsql",otel_scope_version="0.26.0"} 0
+# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes gauge
+go_memstats_heap_released_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE go_memstats_mspan_sys_bytes gauge
+go_memstats_mspan_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE go_memstats_stack_inuse_bytes gauge
+go_memstats_stack_inuse_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE go_memstats_heap_alloc_bytes gauge
+go_memstats_heap_alloc_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+go_memstats_last_gc_time_seconds{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP go_threads Number of OS threads created.
+# TYPE go_threads gauge
+go_threads{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP process_runtime_go_mem_heap_inuse_bytes Bytes in in-use spans
+# TYPE process_runtime_go_mem_heap_inuse_bytes gauge
+process_runtime_go_mem_heap_inuse_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
+# TYPE process_virtual_memory_max_bytes gauge
+process_virtual_memory_max_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP db_sql_connection_wait_total The total number of connections waited for
+# TYPE db_sql_connection_wait_total counter
+db_sql_connection_wait_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="github.com/XSAM/otelsql",otel_scope_version="0.26.0"} 0
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE go_memstats_heap_idle_bytes gauge
+go_memstats_heap_idle_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP process_runtime_go_mem_heap_alloc_bytes Bytes of allocated heap objects
+# TYPE process_runtime_go_mem_heap_alloc_bytes gauge
+process_runtime_go_mem_heap_alloc_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
+# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",quantile="0"} 0
+go_gc_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",quantile="0.25"} 0
+go_gc_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",quantile="0.5"} 0
+go_gc_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",quantile="0.75"} 0
+go_gc_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",quantile="1"} 0
+go_gc_duration_seconds_sum{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+go_gc_duration_seconds_count{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+go_memstats_mcache_inuse_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP http_server_duration_milliseconds Measures the duration of inbound HTTP requests.
+# TYPE http_server_duration_milliseconds histogram
+http_server_duration_milliseconds_bucket{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",http_method="GET",http_scheme="http",http_status_code="200",net_host_name="abcdefghijkl.supabase.co",net_protocol_name="http",net_protocol_version="1.1",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",otel_scope_version="0.51.0",le="0"} 0
+http_server_duration_milliseconds_bucket{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",http_method="GET",http_scheme="http",http_status_code="200",net_host_name="abcdefghijkl.supabase.co",net_protocol_name="http",net_protocol_version="1.1",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",otel_scope_version="0.51.0",le="5"} 0
+http_server_duration_milliseconds_bucket{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",http_method="GET",http_scheme="http",http_status_code="200",net_host_name="abcdefghijkl.supabase.co",net_protocol_name="http",net_protocol_version="1.1",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",otel_scope_version="0.51.0",le="10"} 0
+http_server_duration_milliseconds_bucket{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",http_method="GET",http_scheme="http",http_status_code="200",net_host_name="abcdefghijkl.supabase.co",net_protocol_name="http",net_protocol_version="1.1",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",otel_scope_version="0.51.0",le="25"} 0
+http_server_duration_milliseconds_bucket{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",http_method="GET",http_scheme="http",http_status_code="200",net_host_name="abcdefghijkl.supabase.co",net_protocol_name="http",net_protocol_version="1.1",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",otel_scope_version="0.51.0",le="50"} 0
+http_server_duration_milliseconds_bucket{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",http_method="GET",http_scheme="http",http_status_code="200",net_host_name="abcdefghijkl.supabase.co",net_protocol_name="http",net_protocol_version="1.1",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",otel_scope_version="0.51.0",le="75"} 0
+http_server_duration_milliseconds_bucket{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",http_method="GET",http_scheme="http",http_status_code="200",net_host_name="abcdefghijkl.supabase.co",net_protocol_name="http",net_protocol_version="1.1",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",otel_scope_version="0.51.0",le="100"} 0
+http_server_duration_milliseconds_bucket{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",http_method="GET",http_scheme="http",http_status_code="200",net_host_name="abcdefghijkl.supabase.co",net_protocol_name="http",net_protocol_version="1.1",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",otel_scope_version="0.51.0",le="250"} 0
+http_server_duration_milliseconds_bucket{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",http_method="GET",http_scheme="http",http_status_code="200",net_host_name="abcdefghijkl.supabase.co",net_protocol_name="http",net_protocol_version="1.1",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",otel_scope_version="0.51.0",le="500"} 0
+http_server_duration_milliseconds_bucket{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",http_method="GET",http_scheme="http",http_status_code="200",net_host_name="abcdefghijkl.supabase.co",net_protocol_name="http",net_protocol_version="1.1",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",otel_scope_version="0.51.0",le="750"} 0
+http_server_duration_milliseconds_bucket{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",http_method="GET",http_scheme="http",http_status_code="200",net_host_name="abcdefghijkl.supabase.co",net_protocol_name="http",net_protocol_version="1.1",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",otel_scope_version="0.51.0",le="1000"} 0
+http_server_duration_milliseconds_bucket{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",http_method="GET",http_scheme="http",http_status_code="200",net_host_name="abcdefghijkl.supabase.co",net_protocol_name="http",net_protocol_version="1.1",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",otel_scope_version="0.51.0",le="2500"} 0
+http_server_duration_milliseconds_bucket{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",http_method="GET",http_scheme="http",http_status_code="200",net_host_name="abcdefghijkl.supabase.co",net_protocol_name="http",net_protocol_version="1.1",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",otel_scope_version="0.51.0",le="5000"} 0
+http_server_duration_milliseconds_bucket{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",http_method="GET",http_scheme="http",http_status_code="200",net_host_name="abcdefghijkl.supabase.co",net_protocol_name="http",net_protocol_version="1.1",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",otel_scope_version="0.51.0",le="7500"} 0
+http_server_duration_milliseconds_bucket{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",http_method="GET",http_scheme="http",http_status_code="200",net_host_name="abcdefghijkl.supabase.co",net_protocol_name="http",net_protocol_version="1.1",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",otel_scope_version="0.51.0",le="10000"} 0
+http_server_duration_milliseconds_bucket{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",http_method="GET",http_scheme="http",http_status_code="200",net_host_name="abcdefghijkl.supabase.co",net_protocol_name="http",net_protocol_version="1.1",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",otel_scope_version="0.51.0",le="+Inf"} 0
+http_server_duration_milliseconds_sum{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",http_method="GET",http_scheme="http",http_status_code="200",net_host_name="abcdefghijkl.supabase.co",net_protocol_name="http",net_protocol_version="1.1",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",otel_scope_version="0.51.0"} 0
+http_server_duration_milliseconds_count{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",http_method="GET",http_scheme="http",http_status_code="200",net_host_name="abcdefghijkl.supabase.co",net_protocol_name="http",net_protocol_version="1.1",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",otel_scope_version="0.51.0"} 0
+# HELP process_runtime_go_cgo_calls Number of cgo calls made by the current process
+# TYPE process_runtime_go_cgo_calls gauge
+process_runtime_go_cgo_calls{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
+# HELP db_sql_connection_open The number of established connections both in use and idle
+# TYPE db_sql_connection_open gauge
+db_sql_connection_open{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="github.com/XSAM/otelsql",otel_scope_version="0.26.0",status="idle"} 0
+db_sql_connection_open{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="github.com/XSAM/otelsql",otel_scope_version="0.26.0",status="inuse"} 0
+# HELP go_memstats_heap_objects Number of allocated objects.
+# TYPE go_memstats_heap_objects gauge
+go_memstats_heap_objects{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE go_memstats_stack_sys_bytes gauge
+go_memstats_stack_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP process_runtime_go_mem_heap_idle_bytes Bytes in idle (unused) spans
+# TYPE process_runtime_go_mem_heap_idle_bytes gauge
+process_runtime_go_mem_heap_idle_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
+# HELP target_info Target metadata
+# TYPE target_info gauge
+target_info{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",service_name="unknown_service:auth",telemetry_sdk_language="go",telemetry_sdk_name="opentelemetry",telemetry_sdk_version="1.26.0"} 0
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+go_memstats_buck_hash_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP go_memstats_mallocs_total Total number of mallocs.
+# TYPE go_memstats_mallocs_total counter
+go_memstats_mallocs_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE go_memstats_heap_inuse_bytes gauge
+go_memstats_heap_inuse_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE go_memstats_next_gc_bytes gauge
+go_memstats_next_gc_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP gotrue_running Whether GoTrue is running (always 1)
+# TYPE gotrue_running gauge
+gotrue_running{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="gotrue",otel_scope_version=""} 0
+# HELP http_server_request_size_bytes_total Measures the size of HTTP request messages.
+# TYPE http_server_request_size_bytes_total counter
+http_server_request_size_bytes_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",http_method="GET",http_scheme="http",http_status_code="200",net_host_name="abcdefghijkl.supabase.co",net_protocol_name="http",net_protocol_version="1.1",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",otel_scope_version="0.51.0"} 0
+# HELP process_runtime_go_goroutines Number of goroutines that currently exist
+# TYPE process_runtime_go_goroutines gauge
+process_runtime_go_goroutines{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
+# HELP db_sql_connection_closed_max_lifetime_total The total number of connections closed due to SetConnMaxLifetime
+# TYPE db_sql_connection_closed_max_lifetime_total counter
+db_sql_connection_closed_max_lifetime_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="github.com/XSAM/otelsql",otel_scope_version="0.26.0"} 0
+# HELP go_memstats_frees_total Total number of frees.
+# TYPE go_memstats_frees_total counter
+go_memstats_frees_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP go_memstats_sys_bytes Number of bytes obtained from system.
+# TYPE go_memstats_sys_bytes gauge
+go_memstats_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP runtime_uptime_milliseconds_total Milliseconds since application was initialized
+# TYPE runtime_uptime_milliseconds_total counter
+runtime_uptime_milliseconds_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE go_memstats_gc_sys_bytes gauge
+go_memstats_gc_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP process_runtime_go_gc_pause_total_ns_total Cumulative nanoseconds in GC stop-the-world pauses since the program started
+# TYPE process_runtime_go_gc_pause_total_ns_total counter
+process_runtime_go_gc_pause_total_ns_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
+# HELP process_runtime_go_mem_live_objects Number of live objects is the number of cumulative Mallocs - Frees
+# TYPE process_runtime_go_mem_live_objects gauge
+process_runtime_go_mem_live_objects{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
+# HELP process_runtime_go_mem_heap_released_bytes Bytes of idle spans whose physical memory has been returned to the OS
+# TYPE process_runtime_go_mem_heap_released_bytes gauge
+process_runtime_go_mem_heap_released_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
+# HELP db_sql_connection_max_open Maximum number of open connections to the database
+# TYPE db_sql_connection_max_open gauge
+db_sql_connection_max_open{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="github.com/XSAM/otelsql",otel_scope_version="0.26.0"} 0
+# HELP go_memstats_lookups_total Total number of pointer lookups.
+# TYPE go_memstats_lookups_total counter
+go_memstats_lookups_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP process_runtime_go_gc_count_total Number of completed garbage collection cycles
+# TYPE process_runtime_go_gc_count_total counter
+process_runtime_go_gc_count_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
+# HELP process_runtime_go_mem_heap_objects Number of allocated heap objects
+# TYPE process_runtime_go_mem_heap_objects gauge
+process_runtime_go_mem_heap_objects{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
+# HELP db_sql_connection_closed_max_idle_total The total number of connections closed due to SetMaxIdleConns
+# TYPE db_sql_connection_closed_max_idle_total counter
+db_sql_connection_closed_max_idle_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="github.com/XSAM/otelsql",otel_scope_version="0.26.0"} 0
+# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+# TYPE go_memstats_alloc_bytes gauge
+go_memstats_alloc_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE go_memstats_alloc_bytes_total counter
+go_memstats_alloc_bytes_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP http_status_codes_total Number of returned HTTP status codes
+# TYPE http_status_codes_total counter
+http_status_codes_total{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",code="200",http_route="/health",otel_scope_name="gotrue",otel_scope_version=""} 0
+# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
+# TYPE promhttp_metric_handler_requests_in_flight gauge
+promhttp_metric_handler_requests_in_flight{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP process_runtime_go_gc_pause_ns Amount of nanoseconds in GC stop-the-world pauses
+# TYPE process_runtime_go_gc_pause_ns histogram
+process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="0"} 0
+process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="5"} 0
+process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="10"} 0
+process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="25"} 0
+process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="50"} 0
+process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="75"} 0
+process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="100"} 0
+process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="250"} 0
+process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="500"} 0
+process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="750"} 0
+process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="1000"} 0
+process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="2500"} 0
+process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="5000"} 0
+process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="7500"} 0
+process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="10000"} 0
+process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="+Inf"} 0
+process_runtime_go_gc_pause_ns_sum{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
+process_runtime_go_gc_pause_ns_count{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
+# HELP go_info Information about the Go environment.
+# TYPE go_info gauge
+go_info{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",version="go1.23.7"} 0
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE go_memstats_mcache_sys_bytes gauge
+go_memstats_mcache_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+go_memstats_mspan_inuse_bytes{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue"} 0
+# HELP otel_scope_info Instrumentation Scope metadata
+# TYPE otel_scope_info gauge
+otel_scope_info{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="github.com/XSAM/otelsql",otel_scope_version="0.26.0"} 0
+otel_scope_info{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",otel_scope_version="0.51.0"} 0
+otel_scope_info{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
+otel_scope_info{supabase_project_ref="abcdefghijkl",supabase_identifier="abcdefghijkl",service_type="gotrue",otel_scope_name="gotrue",otel_scope_version=""} 0

--- a/metrics.md
+++ b/metrics.md
@@ -1,0 +1,1031 @@
+# HELP node_memory_SUnreclaim_bytes Memory information field SUnreclaim_bytes.
+# TYPE node_memory_SUnreclaim_bytes gauge
+node_memory_SUnreclaim_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_vmstat_oom_kill /proc/vmstat information field oom_kill.
+# TYPE node_vmstat_oom_kill untyped
+node_vmstat_oom_kill{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP pgbouncer_databases_pool_size Maximum number of server connections
+# TYPE pgbouncer_databases_pool_size gauge
+pgbouncer_databases_pool_size{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",force_user="pgbouncer",host="",name="pgbouncer",pool_mode="statement",port="6543"} 0
+# HELP node_network_transmit_errs_total Network device statistic transmit_errs.
+# TYPE node_network_transmit_errs_total counter
+node_network_transmit_errs_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
+# HELP node_memory_Active_anon_bytes Memory information field Active_anon_bytes.
+# TYPE node_memory_Active_anon_bytes gauge
+node_memory_Active_anon_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_memory_SwapTotal_bytes Memory information field SwapTotal_bytes.
+# TYPE node_memory_SwapTotal_bytes gauge
+node_memory_SwapTotal_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP pgbouncer_databases_disabled 1 if this database is currently disabled, else 0
+# TYPE pgbouncer_databases_disabled gauge
+pgbouncer_databases_disabled{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",force_user="pgbouncer",host="",name="pgbouncer",pool_mode="statement",port="6543"} 0
+# HELP pgbouncer_free_clients Count of free clients
+# TYPE pgbouncer_free_clients gauge
+pgbouncer_free_clients{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_filesystem_files Filesystem total file nodes.
+# TYPE node_filesystem_files gauge
+node_filesystem_files{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="/dev/nvme0n1p2",device_error="",fstype="ext4",mountpoint="/"} 0
+node_filesystem_files{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="/dev/nvme1n1",device_error="",fstype="ext4",mountpoint="/data"} 0
+# HELP node_memory_Inactive_anon_bytes Memory information field Inactive_anon_bytes.
+# TYPE node_memory_Inactive_anon_bytes gauge
+node_memory_Inactive_anon_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP pgbouncer_stats_queries_pooled_total Total number of SQL queries pooled
+# TYPE pgbouncer_stats_queries_pooled_total counter
+pgbouncer_stats_queries_pooled_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer"} 0
+# HELP node_network_transmit_drop_total Network device statistic transmit_drop.
+# TYPE node_network_transmit_drop_total counter
+node_network_transmit_drop_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
+# HELP node_disk_flush_requests_time_seconds_total This is the total number of seconds spent by all flush requests.
+# TYPE node_disk_flush_requests_time_seconds_total counter
+node_disk_flush_requests_time_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
+node_disk_flush_requests_time_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
+# HELP node_disk_discards_merged_total The total number of discards merged.
+# TYPE node_disk_discards_merged_total counter
+node_disk_discards_merged_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
+node_disk_discards_merged_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
+# HELP node_memory_MemTotal_bytes Memory information field MemTotal_bytes.
+# TYPE node_memory_MemTotal_bytes gauge
+node_memory_MemTotal_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_memory_ShmemPmdMapped_bytes Memory information field ShmemPmdMapped_bytes.
+# TYPE node_memory_ShmemPmdMapped_bytes gauge
+node_memory_ShmemPmdMapped_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP pgbouncer_databases_current_connections Current number of connections for this database
+# TYPE pgbouncer_databases_current_connections gauge
+pgbouncer_databases_current_connections{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",force_user="pgbouncer",host="",name="pgbouncer",pool_mode="statement",port="6543"} 0
+# HELP pgbouncer_pools_client_waiting_connections Client connections waiting on a server connection, shown as connection
+# TYPE pgbouncer_pools_client_waiting_connections gauge
+pgbouncer_pools_client_waiting_connections{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",user="pgbouncer"} 0
+# HELP node_memory_HardwareCorrupted_bytes Memory information field HardwareCorrupted_bytes.
+# TYPE node_memory_HardwareCorrupted_bytes gauge
+node_memory_HardwareCorrupted_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_vmstat_pgpgin /proc/vmstat information field pgpgin.
+# TYPE node_vmstat_pgpgin untyped
+node_vmstat_pgpgin{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_disk_read_time_seconds_total The total number of seconds spent by all reads.
+# TYPE node_disk_read_time_seconds_total counter
+node_disk_read_time_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
+node_disk_read_time_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
+# HELP node_filesystem_files_free Filesystem total free file nodes.
+# TYPE node_filesystem_files_free gauge
+node_filesystem_files_free{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="/dev/nvme0n1p2",device_error="",fstype="ext4",mountpoint="/"} 0
+node_filesystem_files_free{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="/dev/nvme1n1",device_error="",fstype="ext4",mountpoint="/data"} 0
+# HELP node_memory_Active_bytes Memory information field Active_bytes.
+# TYPE node_memory_Active_bytes gauge
+node_memory_Active_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_network_receive_drop_total Network device statistic receive_drop.
+# TYPE node_network_receive_drop_total counter
+node_network_receive_drop_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
+# HELP node_network_receive_nohandler_total Network device statistic receive_nohandler.
+# TYPE node_network_receive_nohandler_total counter
+node_network_receive_nohandler_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
+# HELP pgbouncer_stats_sql_transactions_pooled_total Total number of SQL transactions pooled
+# TYPE pgbouncer_stats_sql_transactions_pooled_total counter
+pgbouncer_stats_sql_transactions_pooled_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer"} 0
+# HELP node_memory_Committed_AS_bytes Memory information field Committed_AS_bytes.
+# TYPE node_memory_Committed_AS_bytes gauge
+node_memory_Committed_AS_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP pgbouncer_in_flight_dns_queries Count of in-flight DNS queries
+# TYPE pgbouncer_in_flight_dns_queries gauge
+pgbouncer_in_flight_dns_queries{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP pgbouncer_pools_server_testing_connections Server connections currently running either server_reset_query or server_check_query, shown as connection
+# TYPE pgbouncer_pools_server_testing_connections gauge
+pgbouncer_pools_server_testing_connections{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",user="pgbouncer"} 0
+# HELP pgbouncer_stats_server_in_transaction_seconds_total Total number of seconds spent by pgbouncer when connected to PostgreSQL in a transaction, either idle in transaction or executing queries
+# TYPE pgbouncer_stats_server_in_transaction_seconds_total counter
+pgbouncer_stats_server_in_transaction_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer"} 0
+# HELP pgbouncer_databases_max_connections Maximum number of allowed connections for this database
+# TYPE pgbouncer_databases_max_connections gauge
+pgbouncer_databases_max_connections{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",force_user="pgbouncer",host="",name="pgbouncer",pool_mode="statement",port="6543"} 0
+# HELP node_cpu_guest_seconds_total Seconds the CPUs spent in guests (VMs) for each mode.
+# TYPE node_cpu_guest_seconds_total counter
+node_cpu_guest_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="0",mode="nice"} 0
+node_cpu_guest_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="0",mode="user"} 0
+node_cpu_guest_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="1",mode="nice"} 0
+node_cpu_guest_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="1",mode="user"} 0
+# HELP node_disk_reads_merged_total The total number of reads merged.
+# TYPE node_disk_reads_merged_total counter
+node_disk_reads_merged_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
+node_disk_reads_merged_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
+# HELP node_memory_KernelStack_bytes Memory information field KernelStack_bytes.
+# TYPE node_memory_KernelStack_bytes gauge
+node_memory_KernelStack_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_memory_PageTables_bytes Memory information field PageTables_bytes.
+# TYPE node_memory_PageTables_bytes gauge
+node_memory_PageTables_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP pgbouncer_free_servers Count of free servers
+# TYPE pgbouncer_free_servers gauge
+pgbouncer_free_servers{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_load1 1m load average.
+# TYPE node_load1 gauge
+node_load1{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_memory_CommitLimit_bytes Memory information field CommitLimit_bytes.
+# TYPE node_memory_CommitLimit_bytes gauge
+node_memory_CommitLimit_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_memory_HugePages_Total Memory information field HugePages_Total.
+# TYPE node_memory_HugePages_Total gauge
+node_memory_HugePages_Total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_filesystem_free_bytes Filesystem free space in bytes.
+# TYPE node_filesystem_free_bytes gauge
+node_filesystem_free_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="/dev/nvme0n1p2",device_error="",fstype="ext4",mountpoint="/"} 0
+node_filesystem_free_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="/dev/nvme1n1",device_error="",fstype="ext4",mountpoint="/data"} 0
+# HELP node_network_receive_multicast_total Network device statistic receive_multicast.
+# TYPE node_network_receive_multicast_total counter
+node_network_receive_multicast_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
+# HELP node_scrape_collector_success node_exporter: Whether a collector succeeded.
+# TYPE node_scrape_collector_success gauge
+node_scrape_collector_success{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",collector="cpu"} 0
+node_scrape_collector_success{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",collector="diskstats"} 0
+node_scrape_collector_success{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",collector="filesystem"} 0
+node_scrape_collector_success{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",collector="loadavg"} 0
+node_scrape_collector_success{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",collector="meminfo"} 0
+node_scrape_collector_success{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",collector="netdev"} 0
+node_scrape_collector_success{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",collector="vmstat"} 0
+# HELP pgbouncer_pools_server_active_cancel_connections Server connections that are currently forwarding a cancel request.
+# TYPE pgbouncer_pools_server_active_cancel_connections gauge
+pgbouncer_pools_server_active_cancel_connections{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",user="pgbouncer"} 0
+# HELP node_filesystem_device_error Whether an error occurred while getting statistics for the given device.
+# TYPE node_filesystem_device_error gauge
+node_filesystem_device_error{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="/dev/nvme0n1p2",device_error="",fstype="ext4",mountpoint="/"} 0
+node_filesystem_device_error{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="/dev/nvme1n1",device_error="",fstype="ext4",mountpoint="/data"} 0
+# HELP node_network_receive_errs_total Network device statistic receive_errs.
+# TYPE node_network_receive_errs_total counter
+node_network_receive_errs_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
+# HELP pgbouncer_login_clients Count of clients in login state
+# TYPE pgbouncer_login_clients gauge
+pgbouncer_login_clients{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP pgbouncer_stats_client_wait_seconds_total Time spent by clients waiting for a server in seconds
+# TYPE pgbouncer_stats_client_wait_seconds_total counter
+pgbouncer_stats_client_wait_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer"} 0
+# HELP pgbouncer_up The pgbouncer scrape succeeded
+# TYPE pgbouncer_up gauge
+pgbouncer_up{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_disk_read_bytes_total The total number of bytes read successfully.
+# TYPE node_disk_read_bytes_total counter
+node_disk_read_bytes_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
+node_disk_read_bytes_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
+# HELP node_disk_written_bytes_total The total number of bytes written successfully.
+# TYPE node_disk_written_bytes_total counter
+node_disk_written_bytes_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
+node_disk_written_bytes_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
+# HELP node_network_receive_frame_total Network device statistic receive_frame.
+# TYPE node_network_receive_frame_total counter
+node_network_receive_frame_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
+# HELP pgbouncer_pools_server_used_connections Server connections idle more than server_check_delay, needing server_check_query, shown as connection
+# TYPE pgbouncer_pools_server_used_connections gauge
+pgbouncer_pools_server_used_connections{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",user="pgbouncer"} 0
+# HELP node_disk_io_time_seconds_total Total seconds spent doing I/Os.
+# TYPE node_disk_io_time_seconds_total counter
+node_disk_io_time_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
+node_disk_io_time_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
+# HELP node_memory_SReclaimable_bytes Memory information field SReclaimable_bytes.
+# TYPE node_memory_SReclaimable_bytes gauge
+node_memory_SReclaimable_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_memory_Slab_bytes Memory information field Slab_bytes.
+# TYPE node_memory_Slab_bytes gauge
+node_memory_Slab_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP pgbouncer_stats_sent_bytes_total Total volume in bytes of network traffic sent by pgbouncer, shown as bytes
+# TYPE pgbouncer_stats_sent_bytes_total counter
+pgbouncer_stats_sent_bytes_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer"} 0
+# HELP node_disk_io_time_weighted_seconds_total The weighted # of seconds spent doing I/Os.
+# TYPE node_disk_io_time_weighted_seconds_total counter
+node_disk_io_time_weighted_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
+node_disk_io_time_weighted_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
+# HELP node_memory_Cached_bytes Memory information field Cached_bytes.
+# TYPE node_memory_Cached_bytes gauge
+node_memory_Cached_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_memory_MemAvailable_bytes Memory information field MemAvailable_bytes.
+# TYPE node_memory_MemAvailable_bytes gauge
+node_memory_MemAvailable_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_memory_Mlocked_bytes Memory information field Mlocked_bytes.
+# TYPE node_memory_Mlocked_bytes gauge
+node_memory_Mlocked_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_memory_VmallocTotal_bytes Memory information field VmallocTotal_bytes.
+# TYPE node_memory_VmallocTotal_bytes gauge
+node_memory_VmallocTotal_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_network_receive_fifo_total Network device statistic receive_fifo.
+# TYPE node_network_receive_fifo_total counter
+node_network_receive_fifo_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
+# HELP node_network_transmit_packets_total Network device statistic transmit_packets.
+# TYPE node_network_transmit_packets_total counter
+node_network_transmit_packets_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
+# HELP pgbouncer_pools Count of pools
+# TYPE pgbouncer_pools gauge
+pgbouncer_pools{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_disk_info Info of /sys/block/<block_device>.
+# TYPE node_disk_info gauge
+node_disk_info{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1",major="259",minor="1",model="Amazon Elastic Block Store",path="pci-0000:00:04.0-nvme-1",revision="1.0",rotational="0",serial="vol000b117c48da3dfe3",wwn="nvme.1d0f-766f6c3030306231313763343864613364666533-416d617a6f6e20456c617374696320426c6f636b2053746f7265-00000001"} 0
+node_disk_info{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1",major="259",minor="0",model="Amazon Elastic Block Store",path="pci-0000:00:1f.0-nvme-1",revision="1.0",rotational="0",serial="vol0700061cdf99ba3cf",wwn="nvme.1d0f-766f6c3037303030363163646639396261336366-416d617a6f6e20456c617374696320426c6f636b2053746f7265-00000001"} 0
+# HELP node_disk_write_time_seconds_total This is the total number of seconds spent by all writes.
+# TYPE node_disk_write_time_seconds_total counter
+node_disk_write_time_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
+node_disk_write_time_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
+# HELP node_filesystem_avail_bytes Filesystem space available to non-root users in bytes.
+# TYPE node_filesystem_avail_bytes gauge
+node_filesystem_avail_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="/dev/nvme0n1p2",device_error="",fstype="ext4",mountpoint="/"} 0
+node_filesystem_avail_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="/dev/nvme1n1",device_error="",fstype="ext4",mountpoint="/data"} 0
+# HELP node_memory_Bounce_bytes Memory information field Bounce_bytes.
+# TYPE node_memory_Bounce_bytes gauge
+node_memory_Bounce_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_memory_Hugepagesize_bytes Memory information field Hugepagesize_bytes.
+# TYPE node_memory_Hugepagesize_bytes gauge
+node_memory_Hugepagesize_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_memory_Inactive_file_bytes Memory information field Inactive_file_bytes.
+# TYPE node_memory_Inactive_file_bytes gauge
+node_memory_Inactive_file_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_network_transmit_fifo_total Network device statistic transmit_fifo.
+# TYPE node_network_transmit_fifo_total counter
+node_network_transmit_fifo_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
+# HELP pgbouncer_pools_client_active_cancel_connections Client connections that have forwarded query cancellations to the server and are waiting for the server response
+# TYPE pgbouncer_pools_client_active_cancel_connections gauge
+pgbouncer_pools_client_active_cancel_connections{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",user="pgbouncer"} 0
+# HELP node_disk_reads_completed_total The total number of reads completed successfully.
+# TYPE node_disk_reads_completed_total counter
+node_disk_reads_completed_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
+node_disk_reads_completed_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
+# HELP node_memory_Inactive_bytes Memory information field Inactive_bytes.
+# TYPE node_memory_Inactive_bytes gauge
+node_memory_Inactive_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_memory_Shmem_bytes Memory information field Shmem_bytes.
+# TYPE node_memory_Shmem_bytes gauge
+node_memory_Shmem_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_load15 15m load average.
+# TYPE node_load15 gauge
+node_load15{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_network_receive_bytes_total Network device statistic receive_bytes.
+# TYPE node_network_receive_bytes_total counter
+node_network_receive_bytes_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
+# HELP pgbouncer_pools_client_maxwait_seconds Age of oldest unserved client connection, shown as second
+# TYPE pgbouncer_pools_client_maxwait_seconds gauge
+pgbouncer_pools_client_maxwait_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",user="pgbouncer"} 0
+# HELP pgbouncer_pools_server_being_canceled_connections Servers that normally could become idle but are waiting to do so until all in-flight cancel requests have completed that were sent to cancel a query on this server.
+# TYPE pgbouncer_pools_server_being_canceled_connections gauge
+pgbouncer_pools_server_being_canceled_connections{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",user="pgbouncer"} 0
+# HELP pgbouncer_version_info The pgbouncer version info
+# TYPE pgbouncer_version_info gauge
+pgbouncer_version_info{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",version="PgBouncer 1.19.0"} 0
+# HELP postgresql_restarts_total Number of times postgresql has been restarted
+# TYPE postgresql_restarts_total counter
+postgresql_restarts_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_memory_MemFree_bytes Memory information field MemFree_bytes.
+# TYPE node_memory_MemFree_bytes gauge
+node_memory_MemFree_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_network_transmit_colls_total Network device statistic transmit_colls.
+# TYPE node_network_transmit_colls_total counter
+node_network_transmit_colls_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
+# HELP node_memory_Active_file_bytes Memory information field Active_file_bytes.
+# TYPE node_memory_Active_file_bytes gauge
+node_memory_Active_file_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_memory_AnonHugePages_bytes Memory information field AnonHugePages_bytes.
+# TYPE node_memory_AnonHugePages_bytes gauge
+node_memory_AnonHugePages_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_memory_Buffers_bytes Memory information field Buffers_bytes.
+# TYPE node_memory_Buffers_bytes gauge
+node_memory_Buffers_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_disk_writes_merged_total The number of writes merged.
+# TYPE node_disk_writes_merged_total counter
+node_disk_writes_merged_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
+node_disk_writes_merged_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
+# HELP node_cpu_online CPUs that are online and being scheduled.
+# TYPE node_cpu_online gauge
+node_cpu_online{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="0"} 0
+node_cpu_online{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="1"} 0
+# HELP node_disk_flush_requests_total The total number of flush requests completed successfully
+# TYPE node_disk_flush_requests_total counter
+node_disk_flush_requests_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
+node_disk_flush_requests_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
+# HELP node_disk_writes_completed_total The total number of writes completed successfully.
+# TYPE node_disk_writes_completed_total counter
+node_disk_writes_completed_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
+node_disk_writes_completed_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
+# HELP node_memory_AnonPages_bytes Memory information field AnonPages_bytes.
+# TYPE node_memory_AnonPages_bytes gauge
+node_memory_AnonPages_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_network_transmit_carrier_total Network device statistic transmit_carrier.
+# TYPE node_network_transmit_carrier_total counter
+node_network_transmit_carrier_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
+# HELP node_disk_io_now The number of I/Os currently in progress.
+# TYPE node_disk_io_now gauge
+node_disk_io_now{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
+node_disk_io_now{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
+# HELP pgbouncer_pools_server_idle_connections Server connections idle and ready for a client query, shown as connection
+# TYPE pgbouncer_pools_server_idle_connections gauge
+pgbouncer_pools_server_idle_connections{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",user="pgbouncer"} 0
+# HELP pgbouncer_stats_received_bytes_total Total volume in bytes of network traffic received by pgbouncer, shown as bytes
+# TYPE pgbouncer_stats_received_bytes_total counter
+pgbouncer_stats_received_bytes_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer"} 0
+# HELP pgbouncer_used_servers Count of used servers
+# TYPE pgbouncer_used_servers gauge
+pgbouncer_used_servers{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_memory_Unevictable_bytes Memory information field Unevictable_bytes.
+# TYPE node_memory_Unevictable_bytes gauge
+node_memory_Unevictable_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_memory_VmallocChunk_bytes Memory information field VmallocChunk_bytes.
+# TYPE node_memory_VmallocChunk_bytes gauge
+node_memory_VmallocChunk_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP pgbouncer_pools_client_waiting_cancel_connections Client connections that have not forwarded query cancellations to the server yet
+# TYPE pgbouncer_pools_client_waiting_cancel_connections gauge
+pgbouncer_pools_client_waiting_cancel_connections{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",user="pgbouncer"} 0
+# HELP node_load5 5m load average.
+# TYPE node_load5 gauge
+node_load5{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_memory_WritebackTmp_bytes Memory information field WritebackTmp_bytes.
+# TYPE node_memory_WritebackTmp_bytes gauge
+node_memory_WritebackTmp_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_disk_filesystem_info Info about disk filesystem.
+# TYPE node_disk_filesystem_info gauge
+node_disk_filesystem_info{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1",type="ext4",usage="filesystem",uuid="b730046d-a571-41bc-b924-feb184b9171c",version="1.0"} 0
+# HELP node_memory_HugePages_Surp Memory information field HugePages_Surp.
+# TYPE node_memory_HugePages_Surp gauge
+node_memory_HugePages_Surp{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_network_transmit_bytes_total Network device statistic transmit_bytes.
+# TYPE node_network_transmit_bytes_total counter
+node_network_transmit_bytes_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
+# HELP node_network_transmit_compressed_total Network device statistic transmit_compressed.
+# TYPE node_network_transmit_compressed_total counter
+node_network_transmit_compressed_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
+# HELP node_disk_discarded_sectors_total The total number of sectors discarded successfully.
+# TYPE node_disk_discarded_sectors_total counter
+node_disk_discarded_sectors_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
+node_disk_discarded_sectors_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
+# HELP node_filesystem_mount_info Filesystem mount information.
+# TYPE node_filesystem_mount_info gauge
+node_filesystem_mount_info{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="/dev/nvme0n1p2",major="259",minor="3",mountpoint="/"} 0
+node_filesystem_mount_info{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="/dev/nvme1n1",major="259",minor="0",mountpoint="/data"} 0
+# HELP node_filesystem_size_bytes Filesystem size in bytes.
+# TYPE node_filesystem_size_bytes gauge
+node_filesystem_size_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="/dev/nvme0n1p2",device_error="",fstype="ext4",mountpoint="/"} 0
+node_filesystem_size_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="/dev/nvme1n1",device_error="",fstype="ext4",mountpoint="/data"} 0
+# HELP node_scrape_collector_duration_seconds node_exporter: Duration of a collector scrape.
+# TYPE node_scrape_collector_duration_seconds gauge
+node_scrape_collector_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",collector="cpu"} 0
+node_scrape_collector_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",collector="diskstats"} 0
+node_scrape_collector_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",collector="filesystem"} 0
+node_scrape_collector_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",collector="loadavg"} 0
+node_scrape_collector_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",collector="meminfo"} 0
+node_scrape_collector_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",collector="netdev"} 0
+node_scrape_collector_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",collector="vmstat"} 0
+# HELP pgbouncer_cached_dns_names Count of DNS names in the cache
+# TYPE pgbouncer_cached_dns_names gauge
+pgbouncer_cached_dns_names{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP pgbouncer_users Count of users
+# TYPE pgbouncer_users gauge
+pgbouncer_users{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_memory_Percpu_bytes Memory information field Percpu_bytes.
+# TYPE node_memory_Percpu_bytes gauge
+node_memory_Percpu_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_memory_SwapFree_bytes Memory information field SwapFree_bytes.
+# TYPE node_memory_SwapFree_bytes gauge
+node_memory_SwapFree_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP pgbouncer_config_max_user_connections Config maximum number of server connections per user
+# TYPE pgbouncer_config_max_user_connections gauge
+pgbouncer_config_max_user_connections{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP pgbouncer_pools_server_login_connections Server connections currently in the process of logging in, shown as connection
+# TYPE pgbouncer_pools_server_login_connections gauge
+pgbouncer_pools_server_login_connections{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",user="pgbouncer"} 0
+# HELP pgbouncer_stats_queries_duration_seconds_total Total number of seconds spent by pgbouncer when actively connected to PostgreSQL, executing queries
+# TYPE pgbouncer_stats_queries_duration_seconds_total counter
+pgbouncer_stats_queries_duration_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer"} 0
+# HELP node_memory_NFS_Unstable_bytes Memory information field NFS_Unstable_bytes.
+# TYPE node_memory_NFS_Unstable_bytes gauge
+node_memory_NFS_Unstable_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP pgbouncer_cached_dns_zones Count of DNS zones in the cache
+# TYPE pgbouncer_cached_dns_zones gauge
+pgbouncer_cached_dns_zones{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP pgbouncer_config_max_client_connections Config maximum number of client connections
+# TYPE pgbouncer_config_max_client_connections gauge
+pgbouncer_config_max_client_connections{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP pgbouncer_databases Count of databases
+# TYPE pgbouncer_databases gauge
+pgbouncer_databases{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP pgbouncer_pools_server_active_connections Server connections linked to a client connection, shown as connection
+# TYPE pgbouncer_pools_server_active_connections gauge
+pgbouncer_pools_server_active_connections{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",user="pgbouncer"} 0
+# HELP node_memory_HugePages_Rsvd Memory information field HugePages_Rsvd.
+# TYPE node_memory_HugePages_Rsvd gauge
+node_memory_HugePages_Rsvd{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP db_transmit_bytes postgres and pgbouncer network transmit bytes
+# TYPE db_transmit_bytes counter
+db_transmit_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_cpu_seconds_total Seconds the CPUs spent in each mode.
+# TYPE node_cpu_seconds_total counter
+node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="0",mode="idle"} 0
+node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="0",mode="iowait"} 0
+node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="0",mode="irq"} 0
+node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="0",mode="nice"} 0
+node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="0",mode="softirq"} 0
+node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="0",mode="steal"} 0
+node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="0",mode="system"} 0
+node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="0",mode="user"} 0
+node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="1",mode="idle"} 0
+node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="1",mode="iowait"} 0
+node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="1",mode="irq"} 0
+node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="1",mode="nice"} 0
+node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="1",mode="softirq"} 0
+node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="1",mode="steal"} 0
+node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="1",mode="system"} 0
+node_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",cpu="1",mode="user"} 0
+# HELP node_memory_Writeback_bytes Memory information field Writeback_bytes.
+# TYPE node_memory_Writeback_bytes gauge
+node_memory_Writeback_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_vmstat_pgfault /proc/vmstat information field pgfault.
+# TYPE node_vmstat_pgfault untyped
+node_vmstat_pgfault{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_vmstat_pswpout /proc/vmstat information field pswpout.
+# TYPE node_vmstat_pswpout untyped
+node_vmstat_pswpout{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP pgbouncer_used_clients Count of used clients
+# TYPE pgbouncer_used_clients gauge
+pgbouncer_used_clients{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_memory_ShmemHugePages_bytes Memory information field ShmemHugePages_bytes.
+# TYPE node_memory_ShmemHugePages_bytes gauge
+node_memory_ShmemHugePages_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_network_receive_packets_total Network device statistic receive_packets.
+# TYPE node_network_receive_packets_total counter
+node_network_receive_packets_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
+# HELP node_vmstat_pgpgout /proc/vmstat information field pgpgout.
+# TYPE node_vmstat_pgpgout untyped
+node_vmstat_pgpgout{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_vmstat_pswpin /proc/vmstat information field pswpin.
+# TYPE node_vmstat_pswpin untyped
+node_vmstat_pswpin{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_disk_discards_completed_total The total number of discards completed successfully.
+# TYPE node_disk_discards_completed_total counter
+node_disk_discards_completed_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
+node_disk_discards_completed_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
+# HELP node_memory_Dirty_bytes Memory information field Dirty_bytes.
+# TYPE node_memory_Dirty_bytes gauge
+node_memory_Dirty_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_memory_Mapped_bytes Memory information field Mapped_bytes.
+# TYPE node_memory_Mapped_bytes gauge
+node_memory_Mapped_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_memory_VmallocUsed_bytes Memory information field VmallocUsed_bytes.
+# TYPE node_memory_VmallocUsed_bytes gauge
+node_memory_VmallocUsed_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_network_receive_compressed_total Network device statistic receive_compressed.
+# TYPE node_network_receive_compressed_total counter
+node_network_receive_compressed_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="ens5"} 0
+# HELP pgbouncer_databases_paused 1 if this database is currently paused, else 0
+# TYPE pgbouncer_databases_paused gauge
+pgbouncer_databases_paused{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",force_user="pgbouncer",host="",name="pgbouncer",pool_mode="statement",port="6543"} 0
+# HELP pgbouncer_pools_client_active_connections Client connections linked to server connection and able to process queries, shown as connection
+# TYPE pgbouncer_pools_client_active_connections gauge
+pgbouncer_pools_client_active_connections{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",user="pgbouncer"} 0
+# HELP node_disk_discard_time_seconds_total This is the total number of seconds spent by all discards.
+# TYPE node_disk_discard_time_seconds_total counter
+node_disk_discard_time_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme0n1"} 0
+node_disk_discard_time_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="nvme1n1"} 0
+# HELP node_filesystem_readonly Filesystem read-only status.
+# TYPE node_filesystem_readonly gauge
+node_filesystem_readonly{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="/dev/nvme0n1p2",device_error="",fstype="ext4",mountpoint="/"} 0
+node_filesystem_readonly{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",device="/dev/nvme1n1",device_error="",fstype="ext4",mountpoint="/data"} 0
+# HELP node_memory_HugePages_Free Memory information field HugePages_Free.
+# TYPE node_memory_HugePages_Free gauge
+node_memory_HugePages_Free{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_memory_SwapCached_bytes Memory information field SwapCached_bytes.
+# TYPE node_memory_SwapCached_bytes gauge
+node_memory_SwapCached_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP node_vmstat_pgmajfault /proc/vmstat information field pgmajfault.
+# TYPE node_vmstat_pgmajfault untyped
+node_vmstat_pgmajfault{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db"} 0
+# HELP pgbouncer_databases_reserve_pool Maximum number of additional connections for this database
+# TYPE pgbouncer_databases_reserve_pool gauge
+pgbouncer_databases_reserve_pool{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="db",database="pgbouncer",force_user="pgbouncer",host="",name="pgbouncer",pool_mode="statement",port="6543"} 0
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+go_memstats_buck_hash_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE go_memstats_mspan_sys_bytes gauge
+go_memstats_mspan_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE go_memstats_next_gc_bytes gauge
+go_memstats_next_gc_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP pg_exporter_user_queries_load_error Whether the user queries file was loaded and parsed successfully (1 for error, 0 for success).
+# TYPE pg_exporter_user_queries_load_error gauge
+pg_exporter_user_queries_load_error{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",filename="/opt/postgres_exporter/queries.yml",hashsum="67fac1f53396bb99d2c2c756b8c52a63cea18f41b5f079bb11a098d8e65007cc"} 0
+# HELP pg_settings_default_transaction_read_only Default transaction mode set to read only
+# TYPE pg_settings_default_transaction_read_only gauge
+pg_settings_default_transaction_read_only{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_database_size_bytes Disk space used by the database
+# TYPE pg_database_size_bytes gauge
+pg_database_size_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",datname="postgres"} 0
+pg_database_size_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",datname="template0"} 0
+pg_database_size_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",datname="template1"} 0
+# HELP pg_exporter_last_scrape_duration_seconds Duration of the last scrape of metrics from PostgreSQL.
+# TYPE pg_exporter_last_scrape_duration_seconds gauge
+pg_exporter_last_scrape_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP pg_ls_archive_statusdir_wal_pending_count Number of not yet archived WAL files
+# TYPE pg_ls_archive_statusdir_wal_pending_count counter
+pg_ls_archive_statusdir_wal_pending_count{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_bgwriter_checkpoint_sync_time_total Time spent synchronizing checkpoint files to disk
+# TYPE pg_stat_bgwriter_checkpoint_sync_time_total counter
+pg_stat_bgwriter_checkpoint_sync_time_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_database_conflicts_confl_bufferpin_total Queries cancelled due to pinned buffers
+# TYPE pg_stat_database_conflicts_confl_bufferpin_total counter
+pg_stat_database_conflicts_confl_bufferpin_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_database_conflicts_confl_tablespace_total Queries cancelled due to dropped tablespaces
+# TYPE pg_stat_database_conflicts_confl_tablespace_total counter
+pg_stat_database_conflicts_confl_tablespace_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE go_memstats_heap_alloc_bytes gauge
+go_memstats_heap_alloc_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP pg_database_size_mb Disk space used by the database
+# TYPE pg_database_size_mb gauge
+pg_database_size_mb{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_database_conflicts_confl_deadlock_total Queries cancelled due to deadlocks
+# TYPE pg_stat_database_conflicts_confl_deadlock_total counter
+pg_stat_database_conflicts_confl_deadlock_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_database_conflicts_confl_snapshot_total Queries cancelled due to old snapshots
+# TYPE pg_stat_database_conflicts_confl_snapshot_total counter
+pg_stat_database_conflicts_confl_snapshot_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_database_most_recent_reset The most recent time one of the databases had its statistics reset
+# TYPE pg_stat_database_most_recent_reset counter
+pg_stat_database_most_recent_reset{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP physical_replication_lag_is_wal_replay_paused Check if WAL replay has been paused
+# TYPE physical_replication_lag_is_wal_replay_paused gauge
+physical_replication_lag_is_wal_replay_paused{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP realtime_postgres_changes_total_subscriptions Total subscription records listening for Postgres changes
+# TYPE realtime_postgres_changes_total_subscriptions gauge
+realtime_postgres_changes_total_subscriptions{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP replication_slots_max_lag_bytes Max Replication Lag
+# TYPE replication_slots_max_lag_bytes gauge
+replication_slots_max_lag_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE go_memstats_gc_sys_bytes gauge
+go_memstats_gc_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP go_memstats_mallocs_total Total number of mallocs.
+# TYPE go_memstats_mallocs_total counter
+go_memstats_mallocs_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE go_memstats_mcache_sys_bytes gauge
+go_memstats_mcache_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE go_memstats_other_sys_bytes gauge
+go_memstats_other_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP go_memstats_sys_bytes Number of bytes obtained from system.
+# TYPE go_memstats_sys_bytes gauge
+go_memstats_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP pg_stat_bgwriter_buffers_backend_fsync_total fsync calls executed by a backend directly
+# TYPE pg_stat_bgwriter_buffers_backend_fsync_total counter
+pg_stat_bgwriter_buffers_backend_fsync_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_bgwriter_buffers_backend_total Buffers written directly by a backend
+# TYPE pg_stat_bgwriter_buffers_backend_total counter
+pg_stat_bgwriter_buffers_backend_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_bgwriter_stats_reset Most recent stat reset time
+# TYPE pg_stat_bgwriter_stats_reset counter
+pg_stat_bgwriter_stats_reset{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_database_blks_hit_total Disk blocks found in buffer cache
+# TYPE pg_stat_database_blks_hit_total counter
+pg_stat_database_blks_hit_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_database_conflicts_total Queries canceled due to conflicts with recovery
+# TYPE pg_stat_database_conflicts_total counter
+pg_stat_database_conflicts_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_database_temp_bytes_total Temp data written by queries
+# TYPE pg_stat_database_temp_bytes_total counter
+pg_stat_database_temp_bytes_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_database_tup_inserted_total Rows inserted
+# TYPE pg_stat_database_tup_inserted_total counter
+pg_stat_database_tup_inserted_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_statements_total_queries Number of times executed
+# TYPE pg_stat_statements_total_queries counter
+pg_stat_statements_total_queries{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_statements_total_time_seconds Total time spent, in seconds
+# TYPE pg_stat_statements_total_time_seconds counter
+pg_stat_statements_total_time_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_wal_size_mb Disk space used by WAL files
+# TYPE pg_wal_size_mb gauge
+pg_wal_size_mb{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP postgres_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, goversion from which postgres_exporter was built, and the goos and goarch for the build.
+# TYPE postgres_exporter_build_info gauge
+postgres_exporter_build_info{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",branch="HEAD",goarch="arm64",goos="linux",goversion="go1.21.3",revision="68c176b8833b7580bf847cecf60f8e0ad5923f9a",tags="unknown",version="0.15.0"} 0
+# HELP connection_stats_connection_count Number of active connections
+# TYPE connection_stats_connection_count gauge
+connection_stats_connection_count{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432",username="authenticator"} 0
+connection_stats_connection_count{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432",username="other"} 0
+connection_stats_connection_count{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432",username="supabase_admin"} 0
+# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE go_memstats_stack_inuse_bytes gauge
+go_memstats_stack_inuse_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP pg_stat_bgwriter_buffers_clean_total Buffers written by bg writter
+# TYPE pg_stat_bgwriter_buffers_clean_total counter
+pg_stat_bgwriter_buffers_clean_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_bgwriter_checkpoints_timed_total Scheduled checkpoints performed
+# TYPE pg_stat_bgwriter_checkpoints_timed_total counter
+pg_stat_bgwriter_checkpoints_timed_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP go_memstats_heap_objects Number of allocated objects.
+# TYPE go_memstats_heap_objects gauge
+go_memstats_heap_objects{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP go_memstats_lookups_total Total number of pointer lookups.
+# TYPE go_memstats_lookups_total counter
+go_memstats_lookups_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP pg_stat_database_deadlocks_total Deadlocks detected
+# TYPE pg_stat_database_deadlocks_total counter
+pg_stat_database_deadlocks_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_database_temp_files_total Temp files created by queries
+# TYPE pg_stat_database_temp_files_total counter
+pg_stat_database_temp_files_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP physical_replication_lag_physical_replication_lag_seconds Physical replication lag in seconds
+# TYPE physical_replication_lag_physical_replication_lag_seconds gauge
+physical_replication_lag_physical_replication_lag_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
+# TYPE process_virtual_memory_max_bytes gauge
+process_virtual_memory_max_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
+# TYPE promhttp_metric_handler_requests_in_flight gauge
+promhttp_metric_handler_requests_in_flight{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE go_memstats_heap_idle_bytes gauge
+go_memstats_heap_idle_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE go_memstats_heap_sys_bytes gauge
+go_memstats_heap_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP go_threads Number of OS threads created.
+# TYPE go_threads gauge
+go_threads{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP pg_stat_activity_xact_runtime Transaction Runtime
+# TYPE pg_stat_activity_xact_runtime gauge
+pg_stat_activity_xact_runtime{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_bgwriter_buffers_alloc_total Buffers allocated
+# TYPE pg_stat_bgwriter_buffers_alloc_total counter
+pg_stat_bgwriter_buffers_alloc_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP supabase_usage_metrics_revised_user_queries_total Unknown metric from supabase_usage_metrics_revised
+# TYPE supabase_usage_metrics_revised_user_queries_total untyped
+supabase_usage_metrics_revised_user_queries_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP auth_users_user_count Number of users in the project db
+# TYPE auth_users_user_count gauge
+auth_users_user_count{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_exporter_last_scrape_error Whether the last scrape of metrics from PostgreSQL resulted in an error (1 for error, 0 for success).
+# TYPE pg_exporter_last_scrape_error gauge
+pg_exporter_last_scrape_error{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP pg_stat_bgwriter_maxwritten_clean_total Number of times bg writer stopped a cleaning scan because it had written too many buffers
+# TYPE pg_stat_bgwriter_maxwritten_clean_total counter
+pg_stat_bgwriter_maxwritten_clean_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_database_num_backends The number of active backends
+# TYPE pg_stat_database_num_backends gauge
+pg_stat_database_num_backends{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_replication_send_lag Max send lag
+# TYPE pg_stat_replication_send_lag gauge
+pg_stat_replication_send_lag{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP physical_replication_lag_is_connected_to_primary Monitor connection to the primary database
+# TYPE physical_replication_lag_is_connected_to_primary gauge
+physical_replication_lag_is_connected_to_primary{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP postgres_exporter_config_last_reload_successful Postgres exporter config loaded successfully.
+# TYPE postgres_exporter_config_last_reload_successful gauge
+postgres_exporter_config_last_reload_successful{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
+# TYPE promhttp_metric_handler_requests_total counter
+promhttp_metric_handler_requests_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",code="200"} 0
+promhttp_metric_handler_requests_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",code="500"} 0
+promhttp_metric_handler_requests_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",code="503"} 0
+# HELP go_memstats_frees_total Total number of frees.
+# TYPE go_memstats_frees_total counter
+go_memstats_frees_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes gauge
+go_memstats_heap_released_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE go_memstats_stack_sys_bytes gauge
+go_memstats_stack_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP go_info Information about the Go environment.
+# TYPE go_info gauge
+go_info{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",version="go1.21.3"} 0
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+go_memstats_mcache_inuse_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP max_connections_connection_count Maximum allowed connections
+# TYPE max_connections_connection_count gauge
+max_connections_connection_count{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_scrape_collector_duration_seconds postgres_exporter: Duration of a collector scrape.
+# TYPE pg_scrape_collector_duration_seconds gauge
+pg_scrape_collector_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",collector="database"} 0
+# HELP pg_stat_database_xact_commit_total Transactions committed
+# TYPE pg_stat_database_xact_commit_total counter
+pg_stat_database_xact_commit_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_status_in_recovery Database in recovery
+# TYPE pg_status_in_recovery gauge
+pg_status_in_recovery{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP postgres_exporter_config_last_reload_success_timestamp_seconds Timestamp of the last successful configuration reload.
+# TYPE postgres_exporter_config_last_reload_success_timestamp_seconds gauge
+postgres_exporter_config_last_reload_success_timestamp_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP pg_scrape_collector_success postgres_exporter: Whether a collector succeeded.
+# TYPE pg_scrape_collector_success gauge
+pg_scrape_collector_success{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",collector="database"} 0
+# HELP pg_stat_bgwriter_checkpoint_write_time_total Time spent writing checkpoint files to disk
+# TYPE pg_stat_bgwriter_checkpoint_write_time_total counter
+pg_stat_bgwriter_checkpoint_write_time_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_database_conflicts_confl_lock_total Queries cancelled due to lock timeouts
+# TYPE pg_stat_database_conflicts_confl_lock_total counter
+pg_stat_database_conflicts_confl_lock_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_up Whether the last scrape of metrics from PostgreSQL was able to connect to the server (1 for yes, 0 for no).
+# TYPE pg_up gauge
+pg_up{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP realtime_postgres_changes_client_subscriptions Client subscriptions listening for Postgres changes
+# TYPE realtime_postgres_changes_client_subscriptions gauge
+realtime_postgres_changes_client_subscriptions{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE go_memstats_heap_inuse_bytes gauge
+go_memstats_heap_inuse_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP pg_exporter_scrapes_total Total number of times PostgreSQL was scraped for metrics.
+# TYPE pg_exporter_scrapes_total counter
+pg_exporter_scrapes_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP pg_stat_database_blks_read_total Number of disk blocks read
+# TYPE pg_stat_database_blks_read_total counter
+pg_stat_database_blks_read_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_database_tup_deleted_total Rows deleted
+# TYPE pg_stat_database_tup_deleted_total counter
+pg_stat_database_tup_deleted_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_database_tup_fetched_total Rows fetched by queries
+# TYPE pg_stat_database_tup_fetched_total counter
+pg_stat_database_tup_fetched_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+go_memstats_last_gc_time_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",quantile="0"} 0
+go_gc_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",quantile="0.25"} 0
+go_gc_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",quantile="0.5"} 0
+go_gc_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",quantile="0.75"} 0
+go_gc_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",quantile="1"} 0
+go_gc_duration_seconds_sum{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+go_gc_duration_seconds_count{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+go_memstats_mspan_inuse_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP pg_stat_bgwriter_buffers_checkpoint_total Buffers written during checkpoints
+# TYPE pg_stat_bgwriter_buffers_checkpoint_total counter
+pg_stat_bgwriter_buffers_checkpoint_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_bgwriter_checkpoints_req_total Requested checkpoints performed
+# TYPE pg_stat_bgwriter_checkpoints_req_total counter
+pg_stat_bgwriter_checkpoints_req_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_database_tup_returned_total Rows returned by queries
+# TYPE pg_stat_database_tup_returned_total counter
+pg_stat_database_tup_returned_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_database_tup_updated_total Rows updated
+# TYPE pg_stat_database_tup_updated_total counter
+pg_stat_database_tup_updated_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP pg_stat_replication_replay_lag Max replay lag
+# TYPE pg_stat_replication_replay_lag gauge
+pg_stat_replication_replay_lag{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+# TYPE go_memstats_alloc_bytes gauge
+go_memstats_alloc_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE go_memstats_alloc_bytes_total counter
+go_memstats_alloc_bytes_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql"} 0
+# HELP pg_stat_database_xact_rollback_total Transactions rolled back
+# TYPE pg_stat_database_xact_rollback_total counter
+pg_stat_database_xact_rollback_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP storage_storage_size_mb The total size used for all storage buckets, in mb
+# TYPE storage_storage_size_mb gauge
+storage_storage_size_mb{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP supabase_usage_metrics_user_queries_total The total number of user queries executed
+# TYPE supabase_usage_metrics_user_queries_total counter
+supabase_usage_metrics_user_queries_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgresql",server="localhost:5432"} 0
+# HELP pgrst_schema_cache_loads_total The total number of times the schema cache was loaded
+# TYPE pgrst_schema_cache_loads_total counter
+pgrst_schema_cache_loads_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgrest",status="FAIL"} 0
+pgrst_schema_cache_loads_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgrest",status="SUCCESS"} 0
+# HELP pgrst_db_pool_max Max pool connections
+# TYPE pgrst_db_pool_max gauge
+pgrst_db_pool_max{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgrest"} 0
+# HELP pgrst_db_pool_waiting Requests waiting to acquire a pool connection
+# TYPE pgrst_db_pool_waiting gauge
+pgrst_db_pool_waiting{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgrest"} 0
+# HELP pgrst_db_pool_available Available connections in the pool
+# TYPE pgrst_db_pool_available gauge
+pgrst_db_pool_available{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgrest"} 0
+# HELP pgrst_db_pool_timeouts_total The total number of pool connection timeouts
+# TYPE pgrst_db_pool_timeouts_total counter
+pgrst_db_pool_timeouts_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgrest"} 0
+# HELP pgrst_schema_cache_query_time_seconds The query time in seconds of the last schema cache load
+# TYPE pgrst_schema_cache_query_time_seconds gauge
+pgrst_schema_cache_query_time_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="postgrest"} 0
+# HELP go_memstats_heap_objects Number of allocated objects.
+# TYPE go_memstats_heap_objects gauge
+go_memstats_heap_objects{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+go_memstats_last_gc_time_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+# HELP go_memstats_mallocs_total Total number of mallocs.
+# TYPE go_memstats_mallocs_total counter
+go_memstats_mallocs_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE go_memstats_stack_inuse_bytes gauge
+go_memstats_stack_inuse_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+# HELP go_threads Number of OS threads created.
+# TYPE go_threads gauge
+go_threads{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE go_memstats_mcache_sys_bytes gauge
+go_memstats_mcache_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+# HELP process_runtime_go_mem_heap_alloc_bytes Bytes of allocated heap objects
+# TYPE process_runtime_go_mem_heap_alloc_bytes gauge
+process_runtime_go_mem_heap_alloc_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
+# HELP db_sql_connection_max_open Maximum number of open connections to the database
+# TYPE db_sql_connection_max_open gauge
+db_sql_connection_max_open{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="github.com/XSAM/otelsql",otel_scope_version="0.26.0"} 0
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE go_memstats_heap_inuse_bytes gauge
+go_memstats_heap_inuse_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE go_memstats_mspan_sys_bytes gauge
+go_memstats_mspan_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+# HELP target_info Target metadata
+# TYPE target_info gauge
+target_info{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",service_name="unknown_service:auth",telemetry_sdk_language="go",telemetry_sdk_name="opentelemetry",telemetry_sdk_version="1.26.0"} 0
+# HELP db_sql_connection_open The number of established connections both in use and idle
+# TYPE db_sql_connection_open gauge
+db_sql_connection_open{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="github.com/XSAM/otelsql",otel_scope_version="0.26.0",status="idle"} 0
+db_sql_connection_open{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="github.com/XSAM/otelsql",otel_scope_version="0.26.0",status="inuse"} 0
+# HELP go_info Information about the Go environment.
+# TYPE go_info gauge
+go_info{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",version="go1.23.7"} 0
+# HELP process_runtime_go_mem_heap_idle_bytes Bytes in idle (unused) spans
+# TYPE process_runtime_go_mem_heap_idle_bytes gauge
+process_runtime_go_mem_heap_idle_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
+# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes gauge
+go_memstats_heap_released_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+# HELP runtime_uptime_milliseconds_total Milliseconds since application was initialized
+# TYPE runtime_uptime_milliseconds_total counter
+runtime_uptime_milliseconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
+# HELP db_sql_connection_closed_max_idle_total The total number of connections closed due to SetMaxIdleConns
+# TYPE db_sql_connection_closed_max_idle_total counter
+db_sql_connection_closed_max_idle_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="github.com/XSAM/otelsql",otel_scope_version="0.26.0"} 0
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE go_memstats_heap_sys_bytes gauge
+go_memstats_heap_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+# HELP process_runtime_go_mem_heap_inuse_bytes Bytes in in-use spans
+# TYPE process_runtime_go_mem_heap_inuse_bytes gauge
+process_runtime_go_mem_heap_inuse_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
+# HELP db_sql_connection_wait_total The total number of connections waited for
+# TYPE db_sql_connection_wait_total counter
+db_sql_connection_wait_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="github.com/XSAM/otelsql",otel_scope_version="0.26.0"} 0
+# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",quantile="0"} 0
+go_gc_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",quantile="0.25"} 0
+go_gc_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",quantile="0.5"} 0
+go_gc_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",quantile="0.75"} 0
+go_gc_duration_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",quantile="1"} 0
+go_gc_duration_seconds_sum{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+go_gc_duration_seconds_count{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+go_memstats_buck_hash_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE go_memstats_heap_idle_bytes gauge
+go_memstats_heap_idle_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+# HELP gotrue_running Whether GoTrue is running (always 1)
+# TYPE gotrue_running gauge
+gotrue_running{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="gotrue",otel_scope_version=""} 0
+# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
+# TYPE promhttp_metric_handler_requests_in_flight gauge
+promhttp_metric_handler_requests_in_flight{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+# HELP process_runtime_go_cgo_calls Number of cgo calls made by the current process
+# TYPE process_runtime_go_cgo_calls gauge
+process_runtime_go_cgo_calls{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
+# HELP process_runtime_go_mem_heap_released_bytes Bytes of idle spans whose physical memory has been returned to the OS
+# TYPE process_runtime_go_mem_heap_released_bytes gauge
+process_runtime_go_mem_heap_released_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
+# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
+# TYPE process_virtual_memory_max_bytes gauge
+process_virtual_memory_max_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+# HELP process_runtime_go_gc_count_total Number of completed garbage collection cycles
+# TYPE process_runtime_go_gc_count_total counter
+process_runtime_go_gc_count_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+go_memstats_mspan_inuse_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+go_memstats_mcache_inuse_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE go_memstats_other_sys_bytes gauge
+go_memstats_other_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+# HELP db_sql_connection_closed_max_idle_time_total The total number of connections closed due to SetConnMaxIdleTime
+# TYPE db_sql_connection_closed_max_idle_time_total counter
+db_sql_connection_closed_max_idle_time_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="github.com/XSAM/otelsql",otel_scope_version="0.26.0"} 0
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE go_memstats_gc_sys_bytes gauge
+go_memstats_gc_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE go_memstats_heap_alloc_bytes gauge
+go_memstats_heap_alloc_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+# HELP otel_scope_info Instrumentation Scope metadata
+# TYPE otel_scope_info gauge
+otel_scope_info{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="github.com/XSAM/otelsql",otel_scope_version="0.26.0"} 0
+otel_scope_info{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
+otel_scope_info{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="gotrue",otel_scope_version=""} 0
+# HELP process_runtime_go_gc_pause_ns Amount of nanoseconds in GC stop-the-world pauses
+# TYPE process_runtime_go_gc_pause_ns histogram
+process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="0"} 0
+process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="5"} 0
+process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="10"} 0
+process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="25"} 0
+process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="50"} 0
+process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="75"} 0
+process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="100"} 0
+process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="250"} 0
+process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="500"} 0
+process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="750"} 0
+process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="1000"} 0
+process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="2500"} 0
+process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="5000"} 0
+process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="7500"} 0
+process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="10000"} 0
+process_runtime_go_gc_pause_ns_bucket{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0",le="+Inf"} 0
+process_runtime_go_gc_pause_ns_sum{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
+process_runtime_go_gc_pause_ns_count{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
+# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
+# TYPE promhttp_metric_handler_requests_total counter
+promhttp_metric_handler_requests_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",code="200"} 0
+promhttp_metric_handler_requests_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",code="500"} 0
+promhttp_metric_handler_requests_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",code="503"} 0
+# HELP process_runtime_go_gc_pause_total_ns_total Cumulative nanoseconds in GC stop-the-world pauses since the program started
+# TYPE process_runtime_go_gc_pause_total_ns_total counter
+process_runtime_go_gc_pause_total_ns_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
+# HELP db_sql_connection_wait_duration_milliseconds_total The total time blocked waiting for a new connection
+# TYPE db_sql_connection_wait_duration_milliseconds_total counter
+db_sql_connection_wait_duration_milliseconds_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="github.com/XSAM/otelsql",otel_scope_version="0.26.0"} 0
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE go_memstats_alloc_bytes_total counter
+go_memstats_alloc_bytes_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE go_memstats_next_gc_bytes gauge
+go_memstats_next_gc_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+# HELP go_memstats_sys_bytes Number of bytes obtained from system.
+# TYPE go_memstats_sys_bytes gauge
+go_memstats_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+# HELP process_runtime_go_mem_lookups_total Number of pointer lookups performed by the runtime
+# TYPE process_runtime_go_mem_lookups_total counter
+process_runtime_go_mem_lookups_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+# HELP db_sql_connection_closed_max_lifetime_total The total number of connections closed due to SetConnMaxLifetime
+# TYPE db_sql_connection_closed_max_lifetime_total counter
+db_sql_connection_closed_max_lifetime_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="github.com/XSAM/otelsql",otel_scope_version="0.26.0"} 0
+# HELP go_memstats_frees_total Total number of frees.
+# TYPE go_memstats_frees_total counter
+go_memstats_frees_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE go_memstats_stack_sys_bytes gauge
+go_memstats_stack_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+# HELP process_runtime_go_mem_heap_objects Number of allocated heap objects
+# TYPE process_runtime_go_mem_heap_objects gauge
+process_runtime_go_mem_heap_objects{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
+# HELP go_memstats_lookups_total Total number of pointer lookups.
+# TYPE go_memstats_lookups_total counter
+go_memstats_lookups_total{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+# HELP process_runtime_go_mem_heap_sys_bytes Bytes of heap memory obtained from the OS
+# TYPE process_runtime_go_mem_heap_sys_bytes gauge
+process_runtime_go_mem_heap_sys_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0
+# HELP process_runtime_go_mem_live_objects Number of live objects is the number of cumulative Mallocs - Frees
+# TYPE process_runtime_go_mem_live_objects gauge
+process_runtime_go_mem_live_objects{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
+# HELP process_runtime_go_goroutines Number of goroutines that currently exist
+# TYPE process_runtime_go_goroutines gauge
+process_runtime_go_goroutines{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue",otel_scope_name="go.opentelemetry.io/contrib/instrumentation/runtime",otel_scope_version="0.45.0"} 0
+# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+# TYPE go_memstats_alloc_bytes gauge
+go_memstats_alloc_bytes{supabase_project_ref="abcdefghijkl",supabase_project_ref="abcdefghijklm",service_type="gotrue"} 0


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update

## What is the current behavior?

Previously, metrics exposed contained the `supabase_project_ref` and this was the same for all instances in a project. This meant:
- Adding additional labels/renaming labels in scrape jobs for replicas
- Difficulty in reusing the same Grafana dashboard

## What is the new behavior?

Metrics now include `supabase_identifier` as well as `supabase_project_ref`. This allows you to reuse the same dashboard, avoid relabelling (if you do not want to) and differentiate between instances at the Prometheus level

The dashboard has been updated to reflect this:
1. Choose a `project_ref` from the `supabase_project_ref` dropdown
2. Choose an instance from the `supabase_identifier` dropdown

Feel free to include screenshots if it includes visual changes.

## Additional context

- You will need to delete/reimport the dashboard from this repository to reflect the changes.
- Your projects on supabase.com are already updated and passing the `supabase_identifier` label in their metrics
- Dashboards through third party integrations (i.e. Grafana or Datadog) are NOT updated; though they are welcome to re-use these dashboards as a base

