### PR TITLE
fix: remove rate function on node_disk_io_now

### DIFF
--- a/dashboard.json
+++ b/dashboard.json
@@ -7577,7 +7577,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "rate(node_disk_io_now{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"})",
+              "expr": "node_disk_io_now{supabase_project_ref=\"$project\", supabase_identifier=~\"${supabase_identifier:pipe}\"}",
               "interval": "",
               "intervalFactor": 4,
               "legendFormat": "{{device}} - IO now",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The `Instantaneous Queue Size` panel doesn't work as the query contains an invalid `rate` function without a range vector.

## What is the new behavior?

The underlying metric is not a counter, so the rate function is not required
